### PR TITLE
fix(dev-migration): duplicate `bomb_time_remaining` on `match_bomb_plants`

### DIFF
--- a/migrations/development/20230630204451-get5db.js
+++ b/migrations/development/20230630204451-get5db.js
@@ -16,17 +16,16 @@ exports.setup = function (options, seedLink) {
 };
 
 exports.up = function (db, callback) {
-  return db.addColumn("match_bomb_plants", "bomb_time_remaining", {
-    type: "int",
-    length: 10,
-    notNull: true,
-    defaultValue: 0
-  });
+  return db.runSql(
+    "ALTER TABLE match_bomb_plants MODIFY COLUMN bomb_time_remaining int(10) NOT NULL DEFAULT 0;"
+  );
 };
 
 exports.down = function (db, callback) {
-  return db.removeColumn("match_bomb_plants", "bomb_time_remaining");
+  return db.runSql(
+    "ALTER TABLE match_bomb_plants MODIFY COLUMN bomb_time_remaining int(10) NOT NULL DEFAULT 0;"
+  );
 };
 exports._meta = {
-  version: 27
+  version: 27,
 };


### PR DESCRIPTION
Column already exists from previous migration: 
https://github.com/French-CSGO/G5API/blob/0dcef39f5a6095fe32f7142d33cacb78729f264f/migrations/development/20230615140704-get5db.js#L66