### PR TITLE
feat: db-settings, access control, auth fixes

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -35,6 +35,7 @@ import passport from "./src/utility/auth.js";
 import {router as v2Router} from "./src/routes/v2/api.js";
 import {router as v2DemoRouter} from "./src/routes/v2/demoapi.js";
 import { router as v2BackupRouter } from "./src/routes/v2/backupapi.js";
+import settingsRouter from "./src/routes/settings.js";
 // End Route Files
 
 
@@ -157,6 +158,7 @@ app.use("/maps", mapListRouter);
 app.use("/v2", v2Router);
 app.use("/v2/demo", v2DemoRouter);
 app.use("/v2/backup", v2BackupRouter);
+app.use("/settings", settingsRouter);
 // END ROUTES
 
 // Steam API Calls.

--- a/bin/www.ts
+++ b/bin/www.ts
@@ -17,6 +17,7 @@ import { createServer } from 'http';
 import config from 'config';
 import { initDiscord } from '../src/services/discord.js';
 import { initTwitch } from '../src/services/twitch.js';
+import { loadSettings } from '../src/services/settings.js';
 
 /**
  * Get port from environment and store in Express.
@@ -39,8 +40,11 @@ server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
 
-initDiscord();
-initTwitch();
+// Chargement des paramètres DB avant init des services
+loadSettings().then(() => {
+  initDiscord();
+  initTwitch();
+});
 
 /**
  * Normalize a port into a number, string, or false.

--- a/config/production.json.template
+++ b/config/production.json.template
@@ -24,37 +24,5 @@
     "host": "$SQLHOST",
     "port": $SQLPORT,
     "connectionLimit": 15
-  },
-  "admins": {
-    "steam_ids": "$ADMINS"
-  },
-  "super_admins": {
-    "steam_ids": "$SUPERADMINS"
-  },
-  "toornament": {
-    "clientId": "$TOORNAMENT_CLIENT_ID",
-    "clientSecret": "$TOORNAMENT_CLIENT_SECRET",
-    "apiKey": "$TOORNAMENT_API_KEY"
-  },
-  "discord": {
-    "token": "$DISCORD_TOKEN",
-    "announceChannelId": "$DISCORD_ANNOUNCECHANNEL",
-    "scoreboardChannelId": "$DISCORD_SCOREBOARD",
-    "scheduleChannelId": "$DISCORD_CHANNEL",
-    "guildId": "$DISCORD_GUILD_ID"
-  },
-  "pterodactyl": {
-    "enabled": $PTERODACTYL_ENABLED,
-    "url": "$PTERODACTYL_URL",
-    "apiKey": "$PTERODACTYL_API_KEY",
-    "shutdownDelay": $PTERODACTYL_SHUTDOWN_DELAY
-  },
-  "twitch": {
-    "enabled": $TWITCH_ENABLED,
-    "username": "$TWITCH_USERNAME",
-    "token": "$TWITCH_TOKEN",
-    "channels": ["$TWITCH_CHANNEL"],
-    "announceMapEnd": true,
-    "announceSeriesEnd": true
   }
 }

--- a/migrations/development/20260311120000-settings.js
+++ b/migrations/development/20260311120000-settings.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    CREATE TABLE IF NOT EXISTS settings (
+      id INT PRIMARY KEY AUTO_INCREMENT,
+      setting_key VARCHAR(128) NOT NULL UNIQUE,
+      setting_value TEXT DEFAULT NULL,
+      updated_at DATETIME DEFAULT NOW() ON UPDATE NOW()
+    );
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql("DROP TABLE IF EXISTS settings;");
+};
+
+exports._meta = {
+  version: 30,
+};

--- a/migrations/production/20260311120000-settings.js
+++ b/migrations/production/20260311120000-settings.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    CREATE TABLE IF NOT EXISTS settings (
+      id INT PRIMARY KEY AUTO_INCREMENT,
+      setting_key VARCHAR(128) NOT NULL UNIQUE,
+      setting_value TEXT DEFAULT NULL,
+      updated_at DATETIME DEFAULT NOW() ON UPDATE NOW()
+    );
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql("DROP TABLE IF EXISTS settings;");
+};
+
+exports._meta = {
+  version: 30,
+};

--- a/migrations/test/20260311120000-settings.js
+++ b/migrations/test/20260311120000-settings.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    CREATE TABLE IF NOT EXISTS settings (
+      id INT PRIMARY KEY AUTO_INCREMENT,
+      setting_key VARCHAR(128) NOT NULL UNIQUE,
+      setting_value TEXT DEFAULT NULL,
+      updated_at DATETIME DEFAULT NOW() ON UPDATE NOW()
+    );
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql("DROP TABLE IF EXISTS settings;");
+};
+
+exports._meta = {
+  version: 30,
+};

--- a/src/routes/matches/matches.ts
+++ b/src/routes/matches/matches.ts
@@ -377,8 +377,6 @@ router.get("/", async (req, res, next) => {
       "mtch.cancelled, mtch.forfeit, mtch.start_time, mtch.end_time, mtch.max_maps, mtch.title, mtch.skip_veto, mtch.private_match, " +
       "mtch.enforce_teams, mtch.min_player_ready, mtch.season_id, mtch.is_pug, usr.name as owner, mp.team1_score as team1_mapscore, mp.team2_score as team2_mapscore " +
       "FROM `match` mtch JOIN user usr ON mtch.user_id = usr.id LEFT JOIN map_stats mp ON mp.match_id = mtch.id " +
-      "WHERE cancelled = 0 " +
-      "OR cancelled IS NULL " +
       "GROUP BY mtch.id " +
       "ORDER BY id DESC";
     const matches: RowDataPacket[] = await db.query(sql);

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -23,7 +23,7 @@ import { ToornamentParticipant } from "../types/toornament/ToornamentParticipant
 import { ToornamentTokenResponse } from "../types/toornament/ToornamentTokenResponse.js";
 import { ToornamentMatch } from "../types/toornament/ToornamentMatch.js";
 
-import config from "config";
+import { getSetting, getSettingBool } from "../services/settings.js";
 
 /**
  * @swagger
@@ -692,9 +692,9 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
 
 async function handleToornamentImport(tournamentId: string, userId: number, reqBody: any) {
 
-  const clientId: string = config.get("toornament.clientId") || '';
-  const clientSecret: string = config.get("toornament.clientSecret") || '';
-  const apiKey: string = config.get("toornament.apiKey") || '';
+  const clientId: string = getSetting("toornament.clientId");
+  const clientSecret: string = getSetting("toornament.clientSecret");
+  const apiKey: string = getSetting("toornament.apiKey");
 
   if (!clientId || !clientSecret || !apiKey) {
     throw new Error("Missing Toornament credentials in environment variables");
@@ -797,9 +797,9 @@ async function handleToornamentImport(tournamentId: string, userId: number, reqB
 }
 
 async function getToornamentToken(): Promise<string> {
-  const clientId: string = config.get("toornament.clientId") || '';
-  const clientSecret: string = config.get("toornament.clientSecret") || '';
-  const apiKey: string = config.get("toornament.apiKey") || '';
+  const clientId: string = getSetting("toornament.clientId");
+  const clientSecret: string = getSetting("toornament.clientSecret");
+  const apiKey: string = getSetting("toornament.apiKey");
   if (!clientId || !clientSecret || !apiKey) {
     throw new Error("Missing Toornament credentials in config");
   }
@@ -832,7 +832,7 @@ router.get("/:season_id/toornament/matches", Utils.ensureAuthenticated, async (r
     const seasonId = parseInt(req.params.season_id);
     const tournamentId = await getSeasonToornamentId(seasonId);
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     const { team_id, status, stage_id, group_id, round_id } = req.query;
 
@@ -913,7 +913,7 @@ router.get("/:season_id/toornament/stages", Utils.ensureAuthenticated, async (re
     const seasonId = parseInt(req.params.season_id);
     const tournamentId = await getSeasonToornamentId(seasonId);
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     const response = await fetch(
       `https://api.toornament.com/organizer/v2/stages?tournament_ids=${tournamentId}`,
@@ -939,7 +939,7 @@ router.get("/:season_id/toornament/matches/:toornament_match_id/prefill", Utils.
     const toornamentMatchId = req.params.toornament_match_id;
     const tournamentId = await getSeasonToornamentId(seasonId);
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     // Get season info + CVARs
     const seasonRows: RowDataPacket[] = await db.query(
@@ -1041,7 +1041,7 @@ router.get("/:season_id/toornament/rounds", Utils.ensureAuthenticated, async (re
     const seasonId = parseInt(req.params.season_id);
     const tournamentId = await getSeasonToornamentId(seasonId);
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     const stagesResp = await fetch(`https://api.toornament.com/organizer/v2/stages?tournament_ids=${tournamentId}`, {
       headers: { "Authorization": `Bearer ${token}`, "x-api-key": apiKey, "Range": "stages=0-49" }
@@ -1101,7 +1101,7 @@ router.patch("/:season_id/toornament/rounds/:round_id/schedule", Utils.ensureAut
 
     const tournamentId = await getSeasonToornamentId(seasonId);
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     // Fetch all matches for this round
     let allMatches: ToornamentMatch[] = [];
@@ -1158,7 +1158,7 @@ router.patch("/:season_id/toornament/matches/:match_id/schedule", Utils.ensureAu
     if (!scheduled_datetime) return res.status(400).json({ message: "scheduled_datetime is required" });
 
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     await fetch(`https://api.toornament.com/organizer/v2/matches/${matchId}`, {
       method: "PATCH",

--- a/src/routes/servers.ts
+++ b/src/routes/servers.ts
@@ -16,7 +16,7 @@ import Utils from "../utility/utils.js";
 import { RowDataPacket } from "mysql2";
 import { GameServerObject } from "../types/servers/GameServerObject.js";
 import fetch from "node-fetch";
-import config from "config";
+import { getSetting, getSettingBool } from "../services/settings.js";
 
 /**
  * @swagger
@@ -151,14 +151,13 @@ router.get("/pterodactyl-list", Utils.ensureAuthenticated, async (req, res, next
       res.status(403).json({ message: "User is not authorized to perform action." });
       return;
     }
-    let enabled = false;
-    try { enabled = config.get("pterodactyl.enabled"); } catch {}
+    const enabled = getSettingBool("pterodactyl.enabled");
     if (!enabled) {
       res.status(503).json({ message: "Pterodactyl integration is not enabled." });
       return;
     }
-    const url: string = (config.get("pterodactyl.url") as string).replace(/\/$/, "");
-    const apiKey: string = config.get("pterodactyl.apiKey");
+    const url: string = getSetting("pterodactyl.url").replace(/\/$/, "");
+    const apiKey: string = getSetting("pterodactyl.apiKey");
 
     let servers: any[] = [];
     let nextPage: string | null = `${url}/api/client?per_page=100`;

--- a/src/routes/servers.ts
+++ b/src/routes/servers.ts
@@ -351,7 +351,7 @@ router.get("/myservers", Utils.ensureAuthenticated, async (req, res, next) => {
  *       500:
  *         $ref: '#/components/responses/Error'
  */
-router.get("/:server_id", Utils.ensureAuthenticated, async (req, res, next) => {
+router.get("/:server_id", async (req, res, next) => {
   try {
     let serverID: number = parseInt(req.params.server_id);
     let sql: string;
@@ -360,14 +360,16 @@ router.get("/:server_id", Utils.ensureAuthenticated, async (req, res, next) => {
       sql =
         "SELECT gs.id, gs.in_use, gs.ip_string, gs.port, gs.rcon_password, gs.display_name, gs.public_server, usr.name, gs.flag, gs.gotv_port, gs.pterodactyl_id FROM game_server gs, user usr WHERE usr.id = gs.user_id AND gs.id = ?";
       server = await db.query(sql, [serverID]);
-    } else {
+    } else if (req.user) {
       sql =
         "SELECT gs.id, gs.in_use, gs.ip_string, gs.port, gs.rcon_password, gs.display_name, gs.public_server, usr.name, gs.flag, gs.gotv_port, gs.pterodactyl_id FROM game_server gs, user usr WHERE usr.id = gs.user_id AND gs.id = ? AND usr.id = ?";
-      server = await db.query(sql, [serverID, req.user?.id]);
+      server = await db.query(sql, [serverID, req.user.id]);
+    } else {
+      server = [];
     }
     if (server.length < 1) {
       // Grab bare min. so a user can see a connect button or the like.
-      sql = "SELECT gs.ip_string, gs.port FROM game_server gs WHERE gs.id = ?";
+      sql = "SELECT gs.ip_string, gs.port, gs.gotv_port, gs.display_name FROM game_server gs WHERE gs.id = ?";
       server = await db.query(sql, [serverID]);
       if (server[0]) {
         server = JSON.parse(JSON.stringify(server[0]));

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -1,0 +1,107 @@
+/**
+ * Route API pour la gestion des paramètres stockés en DB.
+ * Accessible uniquement aux super_admins.
+ *
+ * GET  /settings        → retourne tous les paramètres
+ * PUT  /settings        → met à jour un ou plusieurs paramètres
+ */
+
+import { Router } from "express";
+import Utils from "../utility/utils.js";
+import { getAllSettings, setSettings, reloadServices } from "../services/settings.js";
+import { Request, Response, NextFunction } from "express";
+
+// Middleware : accessible aux super_admins uniquement
+function requireSuperAdmin(req: Request, res: Response, next: NextFunction) {
+  if (!req.user || !Utils.superAdminCheck(req.user)) {
+    return res.status(403).json({ message: "Accès réservé aux super-administrateurs." });
+  }
+  return next();
+}
+
+const router = Router();
+
+/**
+ * @swagger
+ * /settings:
+ *   get:
+ *     summary: Retourne tous les paramètres de configuration
+ *     tags: [Settings]
+ *     security:
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Paramètres retournés
+ *       403:
+ *         description: Accès refusé
+ */
+router.get("/", Utils.ensureAuthenticated, requireSuperAdmin, async (req: Request, res: Response) => {
+  const settings = getAllSettings();
+  // Masque les tokens/clés sensibles si demandé avec ?safe=1
+  if (req.query.safe === "1") {
+    const safe: Record<string, string> = {};
+    for (const [k, v] of Object.entries(settings)) {
+      if (k.includes("token") || k.includes("apiKey") || k.includes("secret") || k.includes("password")) {
+        safe[k] = v ? "****" : "";
+      } else {
+        safe[k] = v;
+      }
+    }
+    return res.json(safe);
+  }
+  return res.json(settings);
+});
+
+/**
+ * @swagger
+ * /settings:
+ *   put:
+ *     summary: Met à jour un ou plusieurs paramètres
+ *     tags: [Settings]
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             additionalProperties:
+ *               type: string
+ *     responses:
+ *       200:
+ *         description: Paramètres mis à jour
+ *       400:
+ *         description: Body invalide
+ *       403:
+ *         description: Accès refusé
+ */
+router.put("/", Utils.ensureAuthenticated, requireSuperAdmin, async (req: Request, res: Response) => {
+  try {
+    const body = req.body;
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return res.status(400).json({ message: "Body invalide : objet attendu." });
+    }
+
+    // Filtre les valeurs non-string
+    const entries: Record<string, string> = {};
+    for (const [k, v] of Object.entries(body)) {
+      if (typeof v === "string" || typeof v === "boolean" || typeof v === "number") {
+        entries[k] = String(v);
+      }
+    }
+
+    await setSettings(entries);
+
+    // Recharge les services en arrière-plan
+    reloadServices().catch(err => console.error("[Settings] reloadServices:", err));
+
+    return res.json({ message: "Paramètres mis à jour.", updated: Object.keys(entries) });
+  } catch (err: unknown) {
+    console.error("[Settings] PUT /settings error:", err);
+    if (err instanceof Error) return res.status(500).json({ message: err.message });
+    return res.status(500).json({ message: "Erreur interne." });
+  }
+});
+
+export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -102,9 +102,16 @@ import { UserObject } from "../types/users/UserObject.js";
  */
 router.get("/", async (req, res) => {
   try {
+    const search = req.query.search as string | undefined;
     let sql: string =
       "SELECT id, name, steam_id, small_image, medium_image, large_image, admin, super_admin FROM user";
-    const users: RowDataPacket[] = await db.query(sql);
+    let params: any[] = [];
+    if (search) {
+      sql += " WHERE name LIKE ? OR steam_id LIKE ?";
+      params = [`%${search}%`, `%${search}%`];
+    }
+    sql += " ORDER BY name ASC";
+    const users: RowDataPacket[] = await db.query(sql, params);
     res.json({ users });
   } catch (err) {
     console.error(err);

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -103,7 +103,7 @@ import { UserObject } from "../types/users/UserObject.js";
 router.get("/", async (req, res) => {
   try {
     let sql: string =
-      "SELECT id, name, steam_id, small_image, medium_image, large_image FROM user";
+      "SELECT id, name, steam_id, small_image, medium_image, large_image, admin, super_admin FROM user";
     const users: RowDataPacket[] = await db.query(sql);
     res.json({ users });
   } catch (err) {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -16,10 +16,6 @@ const dbCfg = {
 const connPool = createPool(dbCfg);
 
 class Database {
-  constructor() {
-    this.setupAdmins();
-  }
-
   async query(sql: string, args?: object): Promise<RowDataPacket[]> {
     try {
       let result: [RowDataPacket[], FieldPacket[]];
@@ -30,26 +26,12 @@ class Database {
       throw error;
     }
   }
-  
+
   async buildUpdateStatement(objValues: IStringIndex): Promise<IStringIndex> {
     for (let key in objValues) {
       if (objValues[key] == null || objValues[key] == undefined) delete objValues[key];
     }
     return objValues;
-  }
-
-  async setupAdmins(): Promise<void> {
-    try {
-      let listOfAdmins: Array<string> = (config.get("admins.steam_ids") as string).split(',');
-      let listofSuperAdmins: Array<string> = (config.get("super_admins.steam_ids") as string).split(',');
-      // Get list of admins from database and compare list and add new admins.
-      let updateAdmins: string = "UPDATE user SET admin = 1 WHERE steam_id IN (?)";
-      let updateSuperAdmins: string = "UPDATE user SET super_admin = 1 WHERE steam_id in(?)";
-      await connPool.query(updateAdmins, [listOfAdmins]);
-      await connPool.query(updateSuperAdmins, [listofSuperAdmins]);
-    } catch (err) {
-      console.error("Failed to import users. " + err);
-    }
   }
 }
 let db = new Database();

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -1,6 +1,6 @@
 import { Client, GatewayIntentBits, TextChannel, REST, Routes, SlashCommandBuilder } from "discord.js";
-import config from "config";
 import { db } from "./db.js";
+import { getSetting } from "./settings.js";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -54,9 +54,9 @@ function saveScheduleMessageId(id: string) {
 
 async function getToornamentToken(): Promise<string | null> {
   try {
-    const clientId: string = config.get("toornament.clientId") || "";
-    const clientSecret: string = config.get("toornament.clientSecret") || "";
-    const apiKey: string = config.get("toornament.apiKey") || "";
+    const clientId: string = getSetting("toornament.clientId");
+    const clientSecret: string = getSetting("toornament.clientSecret");
+    const apiKey: string = getSetting("toornament.apiKey");
     if (!clientId || !clientSecret || !apiKey ||
         clientId === "toornament_client_id_go_here") return null;
     const tokenResponse = await fetch("https://api.toornament.com/oauth/v2/token", {
@@ -78,11 +78,11 @@ async function getToornamentToken(): Promise<string | null> {
 
 export async function initDiscord(): Promise<void> {
   try {
-    const token: string = config.get("discord.token");
+    const token: string = getSetting("discord.token");
     if (!token) return;
-    announceChannelId = config.get("discord.announceChannelId");
-    scoreboardChannelId = config.get("discord.scoreboardChannelId");
-    scheduleChannelId = config.get("discord.scheduleChannelId");
+    announceChannelId = getSetting("discord.announceChannelId");
+    scoreboardChannelId = getSetting("discord.scoreboardChannelId");
+    scheduleChannelId = getSetting("discord.scheduleChannelId");
     loadMessageId();
     loadScheduleMessageId();
 
@@ -97,7 +97,7 @@ export async function initDiscord(): Promise<void> {
           .toJSON()
       ];
       const rest = new REST().setToken(token);
-      const guildId: string = config.get("discord.guildId");
+      const guildId: string = getSetting("discord.guildId");
       if (guildId) {
         await rest.put(Routes.applicationGuildCommands(c.user.id, guildId), { body: commands });
       } else {
@@ -212,7 +212,7 @@ export async function updateSchedule(): Promise<void> {
   if (!client?.isReady() || !scheduleChannelId) return;
   try {
     const token = await getToornamentToken();
-    const apiKey: string = config.get("toornament.apiKey") || "";
+    const apiKey: string = getSetting("toornament.apiKey");
 
     const seasons: RowDataPacket[] = await db.query(
       "SELECT id, name, challonge_url FROM season WHERE challonge_url LIKE 't:%'",

--- a/src/services/pterodactyl.ts
+++ b/src/services/pterodactyl.ts
@@ -4,20 +4,16 @@
  */
 
 import fetch from "node-fetch";
-import config from "config";
 import GameServer from "../utility/serverrcon.js";
+import { getSetting, getSettingBool, getSettingInt } from "./settings.js";
 
 function isEnabled(): boolean {
-  try {
-    return config.get("pterodactyl.enabled") === true;
-  } catch {
-    return false;
-  }
+  return getSettingBool("pterodactyl.enabled");
 }
 
 function getConfig() {
-  const url: string = config.get("pterodactyl.url");
-  const apiKey: string = config.get("pterodactyl.apiKey");
+  const url: string = getSetting("pterodactyl.url");
+  const apiKey: string = getSetting("pterodactyl.apiKey");
   return { url: url.replace(/\/$/, ""), apiKey };
 }
 
@@ -126,11 +122,7 @@ export async function stopAfterDelay(
 
   let delay = delayMs;
   if (delay === undefined) {
-    try {
-      delay = config.get<number>("pterodactyl.shutdownDelay");
-    } catch {
-      delay = 300000; // 5 minutes default
-    }
+    delay = getSettingInt("pterodactyl.shutdownDelay") || 300000;
   }
 
   console.log(`[Pterodactyl] Scheduling stop of server ${pterodactylId} in ${delay! / 1000}s`);
@@ -146,11 +138,7 @@ export async function stopAfterDelay(
 }
 
 export function getShutdownDelay(): number {
-  try {
-    return config.get<number>("pterodactyl.shutdownDelay");
-  } catch {
-    return 300000;
-  }
+  return getSettingInt("pterodactyl.shutdownDelay") || 300000;
 }
 
 export { isEnabled };

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,0 +1,150 @@
+/**
+ * Service de configuration stockée en base de données.
+ * Remplace la lecture de config.get() pour toutes les clés non-essentielles au démarrage.
+ *
+ * Architecture :
+ *  - Cache en mémoire (Map) chargé au démarrage
+ *  - Toute écriture met à jour la DB ET le cache
+ *  - Les services (discord, twitch, pterodactyl) rechargent leurs paramètres via reloadServices()
+ */
+
+import { db } from "./db.js";
+import { RowDataPacket } from "mysql2";
+
+// ─── Cache en mémoire ────────────────────────────────────────────────────────
+
+const cache = new Map<string, string | null>();
+let loaded = false;
+
+// ─── Valeurs par défaut ───────────────────────────────────────────────────────
+
+const DEFAULTS: Record<string, string> = {
+  // Discord
+  "discord.enabled": "false",
+  "discord.token": "",
+  "discord.announceChannelId": "",
+  "discord.scoreboardChannelId": "",
+  "discord.scheduleChannelId": "",
+  "discord.guildId": "",
+
+  // Twitch
+  "twitch.enabled": "false",
+  "twitch.username": "",
+  "twitch.token": "",
+  "twitch.channels": "[]",
+
+  // Pterodactyl
+  "pterodactyl.enabled": "false",
+  "pterodactyl.url": "",
+  "pterodactyl.apiKey": "",
+  "pterodactyl.shutdownDelay": "300000",
+
+  // Toornament
+  "toornament.clientId": "",
+  "toornament.clientSecret": "",
+  "toornament.apiKey": "",
+};
+
+// ─── Chargement initial ───────────────────────────────────────────────────────
+
+/**
+ * Charge toutes les clés depuis la DB dans le cache.
+ * Appeler une fois au démarrage.
+ */
+export async function loadSettings(): Promise<void> {
+  try {
+    const rows: RowDataPacket[] = await db.query(
+      "SELECT setting_key, setting_value FROM settings",
+      []
+    );
+    for (const row of rows) {
+      cache.set(row.setting_key, row.setting_value);
+    }
+    loaded = true;
+    console.log(`[Settings] ${rows.length} paramètre(s) chargé(s) depuis la DB.`);
+  } catch (err) {
+    console.error("[Settings] Impossible de charger les paramètres depuis la DB :", err);
+    loaded = true; // continue avec les valeurs par défaut
+  }
+}
+
+// ─── Getters ─────────────────────────────────────────────────────────────────
+
+/**
+ * Retourne la valeur d'une clé (depuis le cache ou la valeur par défaut).
+ */
+export function getSetting(key: string): string {
+  if (cache.has(key)) {
+    return cache.get(key) ?? DEFAULTS[key] ?? "";
+  }
+  return DEFAULTS[key] ?? "";
+}
+
+export function getSettingBool(key: string): boolean {
+  return getSetting(key) === "true";
+}
+
+export function getSettingInt(key: string): number {
+  return parseInt(getSetting(key)) || 0;
+}
+
+/**
+ * Retourne toutes les clés connues avec leur valeur actuelle.
+ */
+export function getAllSettings(): Record<string, string> {
+  const result: Record<string, string> = { ...DEFAULTS };
+  for (const [k, v] of cache.entries()) {
+    result[k] = v ?? "";
+  }
+  return result;
+}
+
+// ─── Setters ─────────────────────────────────────────────────────────────────
+
+/**
+ * Met à jour une clé en DB et dans le cache.
+ */
+export async function setSetting(key: string, value: string): Promise<void> {
+  await db.query(
+    "INSERT INTO settings (setting_key, setting_value) VALUES (?, ?) " +
+    "ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), updated_at = NOW()",
+    [key, value]
+  );
+  cache.set(key, value);
+}
+
+/**
+ * Met à jour plusieurs clés en une seule opération.
+ */
+export async function setSettings(entries: Record<string, string>): Promise<void> {
+  for (const [key, value] of Object.entries(entries)) {
+    await setSetting(key, value);
+  }
+}
+
+// ─── Callbacks de rechargement ────────────────────────────────────────────────
+
+type ReloadFn = () => Promise<void>;
+const reloadCallbacks: ReloadFn[] = [];
+
+/**
+ * Enregistre une fonction de rechargement (appelée par discord.ts, twitch.ts, etc.)
+ */
+export function onSettingsReload(fn: ReloadFn): void {
+  reloadCallbacks.push(fn);
+}
+
+/**
+ * Recharge tous les services enregistrés.
+ * Appelé après une modification de paramètres via l'API.
+ */
+export async function reloadServices(): Promise<void> {
+  await loadSettings();
+  for (const fn of reloadCallbacks) {
+    try {
+      await fn();
+    } catch (err) {
+      console.error("[Settings] Erreur lors du rechargement d'un service :", err);
+    }
+  }
+}

--- a/src/services/toornament.ts
+++ b/src/services/toornament.ts
@@ -13,7 +13,7 @@ import { db } from "../services/db.js";
 
 import { RowDataPacket } from "mysql2";
 
-import config from "config";
+import { getSetting } from "./settings.js";
 
 import { ToornamentTokenResponse } from "../types/toornament/ToornamentTokenResponse.js";
 import { ToornamentMatch } from "../types/toornament/ToornamentMatch.js";
@@ -30,12 +30,12 @@ export default
     ): Promise<void> {
 
 
-    const clientId: string = config.get("toornament.clientId") || '';
-    const clientSecret: string = config.get("toornament.clientSecret") || '';
-    const apiKey: string = config.get("toornament.apiKey") || '';
+    const clientId: string = getSetting("toornament.clientId");
+    const clientSecret: string = getSetting("toornament.clientSecret");
+    const apiKey: string = getSetting("toornament.apiKey");
 
     if (!clientId || !clientSecret || !apiKey) {
-        throw new Error("Missing Toornament credentials in environment variables");
+        throw new Error("Missing Toornament credentials in settings");
     }
 
     let sql: string = "SELECT challonge_team_id FROM team WHERE id = ?";

--- a/src/services/twitch.ts
+++ b/src/services/twitch.ts
@@ -14,8 +14,8 @@
  */
 
 import tmi from "tmi.js";
-import config from "config";
 import { db } from "./db.js";
+import { getSetting, getSettingBool, onSettingsReload } from "./settings.js";
 import GlobalEmitter from "../utility/emitter.js";
 import { RowDataPacket } from "mysql2";
 
@@ -61,25 +61,31 @@ const COMMAND_COOLDOWN_SEC = 5;
 
 export async function initTwitch(): Promise<void> {
   try {
-    // Lecture de la config (token, channel, etc.)
-    const twitchConfig = config.has("twitch") ? config.get<Record<string, any>>("twitch") : {};
-    enabled = !!(twitchConfig as any)?.enabled;
+    // Lecture de la config depuis la DB
+    enabled = getSettingBool("twitch.enabled");
 
     if (!enabled) {
-      console.log("[Twitch] Bot désactivé (twitch.enabled = false dans la config).");
+      console.log("[Twitch] Bot désactivé (twitch.enabled = false).");
       return;
     }
 
-    const token: string = (twitchConfig as any)?.token || "";
-    const username: string = (twitchConfig as any)?.username || "";
-    const rawChannels: string | string[] = (twitchConfig as any)?.channels || [];
+    const token: string = getSetting("twitch.token");
+    const username: string = getSetting("twitch.username");
+    // channels stocké en JSON : '["channel1","channel2"]' ou "channel1"
+    let rawChannels: string = getSetting("twitch.channels");
 
     if (!token || !username) {
-      console.warn("[Twitch] token ou username manquant dans la config — bot non démarré.");
+      console.warn("[Twitch] token ou username manquant — bot non démarré.");
       return;
     }
 
-    channels = Array.isArray(rawChannels) ? rawChannels : [rawChannels];
+    try {
+      const parsed = JSON.parse(rawChannels);
+      channels = Array.isArray(parsed) ? parsed : [String(parsed)];
+    } catch {
+      channels = rawChannels ? [rawChannels] : [];
+    }
+
     if (!channels.length) {
       console.warn("[Twitch] Aucun channel configuré (twitch.channels) — bot non démarré.");
       return;
@@ -112,6 +118,18 @@ export async function initTwitch(): Promise<void> {
     GlobalEmitter.on("matchUpdate", onMatchUpdate);
     GlobalEmitter.on("mapStatUpdate", onMapStatUpdate);
     GlobalEmitter.on("playerStatsUpdate", onPlayerStatsUpdate);
+
+    // Enregistre le rechargement automatique si les settings changent
+    onSettingsReload(async () => {
+      if (client) {
+        try { await client.disconnect(); } catch {}
+        client = null;
+      }
+      GlobalEmitter.removeListener("matchUpdate", onMatchUpdate);
+      GlobalEmitter.removeListener("mapStatUpdate", onMapStatUpdate);
+      GlobalEmitter.removeListener("playerStatsUpdate", onPlayerStatsUpdate);
+      await initTwitch();
+    });
 
     console.log("[Twitch] Bot prêt.");
   } catch (err) {

--- a/src/utility/auth.ts
+++ b/src/utility/auth.ts
@@ -86,12 +86,14 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
         sql = "INSERT INTO map_list (map_name, map_display_name, user_id) VALUES ?";
         await db.query(sql, [defaultMaps]);
       } else {
+        isAdmin = curUser[0].admin;
+        isSuperAdmin = curUser[0].super_admin;
         let updateUser = {
           small_image: profile.photos[0].value,
           medium_image: profile.photos[1].value,
           large_image: profile.photos[2].value,
-          super_admin: curUser[0].super_admin,
-          admin: curUser[0].admin
+          super_admin: isSuperAdmin,
+          admin: isAdmin
         };
         sql = "UPDATE user SET ? WHERE steam_id=?";
         await db.query(sql, [updateUser, profile.id]);

--- a/src/utility/auth.ts
+++ b/src/utility/auth.ts
@@ -52,15 +52,7 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
       let defaultMaps = [];
       let isAdmin = 0;
       let isSuperAdmin = 0;
-      let superAdminList = (config.get("super_admins.steam_ids") as String).split(",");
-      let adminList = (config.get("admins.steam_ids") as String).split(",");
       let sql = "SELECT * FROM user WHERE steam_id = ?";
-      // If we are an admin, check!
-      if (superAdminList.indexOf(profile.id!.toString()) >= 0) {
-        isSuperAdmin = 1;
-      } else if (adminList.indexOf(profile.id!.toString()) >= 0) {
-        isAdmin = 1;
-      }
       let curUser = await db.query(sql, profile.id);
       if (curUser.length < 1) {
         //Generate API key in user session to allow posting/getting/etc with
@@ -98,8 +90,8 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
           small_image: profile.photos[0].value,
           medium_image: profile.photos[1].value,
           large_image: profile.photos[2].value,
-          super_admin: isSuperAdmin,
-          admin: isAdmin
+          super_admin: curUser[0].super_admin,
+          admin: curUser[0].admin
         };
         sql = "UPDATE user SET ? WHERE steam_id=?";
         await db.query(sql, [updateUser, profile.id]);
@@ -186,9 +178,8 @@ passport.use('local-register',
       }
       let sql = "SELECT * FROM user WHERE username = ? OR steam_id = ?";
       let defaultMaps = [];
-      let superAdminList = (config.get("super_admins.steam_ids") as String).split(",");
-      let adminList = (config.get("admins.steam_ids") as String).split(",");
-      let isAdmin, isSuperAdmin = 0;
+      let isAdmin = 0;
+      let isSuperAdmin = 0;
       if (!req.body.steam_id) {
         return done(null, false, {message: "Steam ID was not provided"});
       }
@@ -199,11 +190,6 @@ passport.use('local-register',
         // Check if steam64 is correct.
         if(await Utils.convertToSteam64(req.body.steam_id) == "") {
           return done(null, false, {message: "Not a valid Steam64 ID."});
-        }
-        if (superAdminList.indexOf(req.body.steam_id) >= 0) {
-          isSuperAdmin = 1;
-        } else if (adminList.indexOf(req.body.steam_id) >= 0) {
-          isAdmin = 1;
         }
         let apiKey = generate({
           length: 64,


### PR DESCRIPTION
- Paramètres déplacés de config vers la DB (getSetting/setSetting)
- Fix session : admin/super_admin toujours à 0 au login → corrigé
- GET /servers/:server_id accessible sans auth (sans rcon_password)
- Toornament : config lue depuis la DB
- GET /matches : plus de filtre cancelled