### PR TITLE
Potential fix for code scanning alert no. 108: Server-side request forgery

### DIFF
--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -1200,6 +1200,10 @@ router.patch("/:season_id/toornament/rounds/:round_id/schedule", Utils.ensureAut
 router.patch("/:season_id/toornament/matches/:match_id/schedule", Utils.ensureAuthenticated, async (req, res) => {
   try {
     const matchId = req.params.match_id;
+    // Validate matchId to avoid using arbitrary user-controlled data in the request URL path
+    if (!/^[A-Za-z0-9_-]+$/.test(matchId)) {
+      return res.status(400).json({ message: "Invalid match_id" });
+    }
     const { scheduled_datetime } = req.body;
     if (!scheduled_datetime) return res.status(400).json({ message: "scheduled_datetime is required" });
 


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/108](https://github.com/French-CSGO/G5API/security/code-scanning/108)

General fix: Validate and constrain user-controlled values before using them in constructing outgoing request URLs. In particular, ensure path components are limited to an expected safe pattern (e.g., numeric IDs or specific allowed characters), rejecting or sanitizing anything else.

Best fix here: Restrict `matchId` to a safe, expected format before using it in the fetch URL. If Toornament match IDs are numeric (very common) we can enforce a digits-only regex; otherwise we can still restrict to a conservative set (e.g., alphanumerics and dashes). The smallest, least invasive change is to:

1. Read `req.params.match_id` as now.
2. Immediately validate it with a regex; if it doesn’t match, return HTTP 400.
3. Use the validated `matchId` variable for the fetch call.

This keeps existing functionality for valid IDs while preventing malformed or exploit attempts from ever reaching the external API. All changes are confined to `src/routes/seasons.ts` in the `router.patch("/:season_id/toornament/matches/:match_id/schedule", ...)` handler. No new imports are needed.

Concretely:
- Around line 1202, add validation logic directly after reading `matchId`.
- For example, require `^[A-Za-z0-9_-]+$` (safe for path segments) or `^[0-9]+$` if IDs are numeric.
- If invalid, `return res.status(400).json({ message: "Invalid match_id" });`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
