### PR TITLE
Potential fix for code scanning alert no. 107: Server-side request forgery

### DIFF
--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -983,6 +983,14 @@ router.get("/:season_id/toornament/matches/:toornament_match_id/prefill", Utils.
   try {
     const seasonId = parseInt(req.params.season_id);
     const toornamentMatchId = req.params.toornament_match_id;
+
+    // Validate Toornament match ID to prevent misuse in outbound requests
+    // Adjust the regex as needed to match the exact format used by Toornament IDs.
+    const toornamentMatchIdPattern = /^[A-Za-z0-9_-]+$/;
+    if (!toornamentMatchId || !toornamentMatchIdPattern.test(toornamentMatchId)) {
+      return res.status(400).json({ message: "Invalid Toornament match ID." });
+    }
+
     const tournamentId = await getSeasonToornamentId(seasonId);
     const token = await getToornamentToken();
     const apiKey: string = getSetting("toornament.apiKey");


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/107](https://github.com/French-CSGO/G5API/security/code-scanning/107)

To fix this, we should ensure that the user-provided `toornament_match_id` is validated or mapped to a safe value before being interpolated into the URL. The main goals are:

1. Prevent path traversal or unexpected characters in the match ID.
2. Constrain the value to the format Toornament actually uses (e.g., UUID-like string).
3. Optionally, reject IDs that are not associated with the given season, if that information is available in the DB (though we cannot add that logic without seeing relevant schema).

The best low-impact fix, without changing overall functionality or imports, is to:

- Introduce a small local validation function (or inline logic) in the `/:season_id/toornament/matches/:toornament_match_id/prefill` route that:
  - Checks `req.params.toornament_match_id` against a strict regular expression allowing only expected characters (for example, alphanumerics and dashes/underscores).
  - Rejects the request with `400 Bad Request` if validation fails.
- Use the validated value for `toornamentMatchId` in the `fetch` call.

Concretely, within `src/routes/seasons.ts`, only in the shown route (lines around 982–1009):

- After reading `const toornamentMatchId = req.params.toornament_match_id;`, add a validation step. If invalid, immediately return a 400 response.
- Do not change the `fetch` URL construction except to rely on the validated ID.
- No new external dependencies are necessary; simple regex validation is sufficient.

This maintains existing behavior for valid IDs while preventing crafted, unexpected path segments from being used in the outgoing HTTP request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
