### PR TITLE
Potential fix for code scanning alert no. 106: Server-side request forgery

### DIFF
--- a/src/routes/teams.ts
+++ b/src/routes/teams.ts
@@ -949,7 +949,43 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res) => {
     let userID: number = req.user!.id;
     const userInfo: RowDataPacket[] = await db.query("SELECT challonge_api_key FROM user WHERE id = ?", [userID]);
     let challongeAPIKey: string | undefined | null = Utils.decrypt(userInfo[0].challonge_api_key);
-    let tournamentId: string = req.body[0].tournament_id;
+    let rawTournamentId: string = req.body[0].tournament_id;
+
+    // Normalize and validate the tournament identifier to avoid SSRF and unexpected URLs.
+    let tournamentId: string;
+    if (typeof rawTournamentId !== "string" || rawTournamentId.trim().length === 0) {
+      return res.status(400).json({ message: "Invalid Challonge tournament identifier." });
+    }
+
+    const trimmedTournamentId = rawTournamentId.trim();
+    if (trimmedTournamentId.startsWith("http://") || trimmedTournamentId.startsWith("https://")) {
+      let parsed: URL;
+      try {
+        parsed = new URL(trimmedTournamentId);
+      } catch {
+        return res.status(400).json({ message: "Invalid Challonge tournament URL." });
+      }
+
+      const hostname = parsed.hostname.toLowerCase();
+      if (hostname !== "challonge.com" && hostname !== "www.challonge.com") {
+        return res.status(400).json({ message: "Tournament URL must point to challonge.com." });
+      }
+
+      const segments = parsed.pathname.split("/").filter(Boolean);
+      const lastSegment = segments[segments.length - 1];
+      if (!lastSegment) {
+        return res.status(400).json({ message: "Could not determine Challonge tournament identifier from URL." });
+      }
+      tournamentId = lastSegment;
+    } else {
+      tournamentId = trimmedTournamentId;
+    }
+
+    // Only allow safe characters in the final tournament identifier.
+    if (!/^[A-Za-z0-9_-]+$/.test(tournamentId)) {
+      return res.status(400).json({ message: "Invalid characters in Challonge tournament identifier." });
+    }
+
     let challongeResponse: any = await fetch("https://api.challonge.com/v1/tournaments/" + tournamentId + "/participants.json?api_key=" + challongeAPIKey);
     let challongeData: any = await challongeResponse.json();
     if (!challongeData) {


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/106](https://github.com/French-CSGO/G5API/security/code-scanning/106)

In general, to fix this kind of problem you must ensure that user input cannot arbitrarily control the URL of outbound requests. Since this code must support “tournament ID or URL” semantics for Challonge, the safest approach is: (1) if the client sends a full Challonge URL, parse it and extract only the permitted path segment (the tournament identifier); (2) otherwise treat the input as a plain identifier. In both cases, rigorously validate the resulting `tournamentId` against a strict allow‑list pattern (for example, only letters, digits, underscore, hyphen) and reject anything else. Finally, always construct the request URL from the known base `"https://api.challonge.com/v1/tournaments/"` plus the sanitized identifier, never directly from an arbitrary URL supplied by the client.

Concretely, inside `router.post("/challonge", ...)` in `src/routes/teams.ts`, we can introduce a small normalization/validation routine for `tournamentId` just after reading `req.body[0].tournament_id`. If the provided value looks like a URL (starts with `http://` or `https://`), we use the standard `URL` class to ensure it is actually a Challonge URL (hostname `challonge.com` or `www.challonge.com`) and then extract the last non-empty path segment as the slug/ID. If it is not a URL, we treat it as a raw ID. In either case, we then validate the final identifier against a regular expression such as `/^[A-Za-z0-9_-]+$/`. If parsing fails, the hostname is not Challonge, or the identifier does not match the regex, we return a 400 error instead of issuing the outbound fetch. After this, we replace the existing `fetch("https://api.challonge.com/v1/tournaments/" + tournamentId + "/participants.json?...` with a version that uses the sanitized `tournamentId`. This preserves existing functionality (clients can still pass a slug or a full Challonge URL) while preventing arbitrary URLs or path traversal from influencing the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
