### PR TITLE
Potential fix for code scanning alert no. 105: Server-side request forgery

### DIFF
--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -736,6 +736,18 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
 });
 
 
+function validateToornamentId(rawId: string): string {
+  // Strip optional "t:" prefix used internally.
+  const id = rawId.replace(/^t:/, '');
+  // Allow only a safe subset of characters and enforce a reasonable length.
+  // Adjust the pattern if Toornament IDs have a stricter known format.
+  const idPattern = /^[A-Za-z0-9_-]{1,128}$/;
+  if (!idPattern.test(id)) {
+    throw new Error("Invalid Toornament tournament id format");
+  }
+  return id;
+}
+
 async function handleToornamentImport(tournamentId: string, userId: number, reqBody: any) {
 
   const clientId: string = getSetting("toornament.clientId");
@@ -761,7 +773,7 @@ async function handleToornamentImport(tournamentId: string, userId: number, reqB
   const tokenData = await tokenResponse.json() as ToornamentTokenResponse;
   if (!tokenData.access_token) throw new Error("Toornament Auth Failed");
 
-  const cleanId = tournamentId.replace(/^t:/, '');
+  const cleanId = validateToornamentId(tournamentId);
   
   const toornamentResponse = await fetch(
     `https://api.toornament.com/organizer/v2/tournaments/${cleanId}`,


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/105](https://github.com/French-CSGO/G5API/security/code-scanning/105)

General approach: sanitize and constrain the user-controlled `tournamentId` before using it in the URL path. We want to ensure that only valid Toornament tournament identifiers are accepted (for example, a specific character set and length), and reject anything that looks like path traversal (`../`) or otherwise unexpected input. This keeps existing behavior for honest input while preventing abuse.

Best concrete fix here:

1. Introduce a small validation function `validateToornamentId` inside `src/routes/seasons.ts` that:
   - Strips the `t:` prefix (as already done).
   - Verifies the cleaned ID against a strict regular expression (e.g., only alphanumeric plus `-` and `_`, with a reasonable length limit).
   - Throws an error if the ID is invalid.
2. Use this function in `handleToornamentImport` to derive a safe `cleanId`, replacing the current `tournamentId.replace(/^t:/, '')` with the validated value.
3. Keep the existing Toornament API request structure; only the sanitization step changes.

Concretely, within `src/routes/seasons.ts`:

- Add a new helper `validateToornamentId` above `handleToornamentImport`.
- Change the line where `cleanId` is computed (line 764) to call `validateToornamentId(tournamentId)` instead of doing the raw `replace`.
- No new imports are necessary; this uses built-in TypeScript/JavaScript features.

This preserves existing functionality for valid IDs (they still work as before), but blocks maliciously crafted `tournament_id` values from influencing the request path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
