### PR TITLE
Potential fix for code scanning alert no. 104: Server-side request forgery

### DIFF
--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -690,7 +690,8 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
           throw "Invalid Challonge tournament URL.";
         }
         const hostname = url.hostname.toLowerCase();
-        if (!hostname.endsWith("challonge.com")) {
+        const allowedChallongeHosts = ["challonge.com", "www.challonge.com"];
+        if (!allowedChallongeHosts.includes(hostname)) {
           throw "Tournament URL must be a challonge.com URL.";
         }
         const pathSegments = url.pathname.split("/").filter(Boolean);

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -674,6 +674,39 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
       return res.json(result);
     }
 
+    // Validate and normalize Challonge tournament identifier or URL
+    const sanitizeChallongeTournamentId = (input: string): string => {
+      const trimmed = (input || "").trim();
+      if (!trimmed) {
+        throw "No Challonge tournament ID provided.";
+      }
+
+      // If a full URL is provided, ensure it points to challonge.com and extract the last path segment.
+      if (/^https?:\/\//i.test(trimmed)) {
+        let url;
+        try {
+          url = new URL(trimmed);
+        } catch {
+          throw "Invalid Challonge tournament URL.";
+        }
+        const hostname = url.hostname.toLowerCase();
+        if (!hostname.endsWith("challonge.com")) {
+          throw "Tournament URL must be a challonge.com URL.";
+        }
+        const pathSegments = url.pathname.split("/").filter(Boolean);
+        const lastSegment = pathSegments[pathSegments.length - 1];
+        if (!lastSegment || !/^[A-Za-z0-9_-]+$/.test(lastSegment)) {
+          throw "Invalid Challonge tournament identifier in URL.";
+        }
+        return lastSegment;
+      }
+
+      // Otherwise, treat as a plain tournament ID/slug and restrict to safe characters.
+      if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) {
+        throw "Invalid Challonge tournament ID.";
+      }
+      return trimmed;
+    };
 
     const userInfo: RowDataPacket[] = await db.query("SELECT challonge_api_key FROM user WHERE id = ?", [req.user!.id]);
     let challongeAPIKey: string | undefined | null = Utils.decrypt(userInfo[0].challonge_api_key);
@@ -681,7 +714,7 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
       throw "No challonge API key provided for user.";
     }
 
-    let tournamentId: string = req.body[0].tournament_id;
+    let tournamentId: string = sanitizeChallongeTournamentId(req.body[0].tournament_id);
     let challongeResponse: any = await fetch(
       "https://api.challonge.com/v1/tournaments/" +
       tournamentId +


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/104](https://github.com/French-CSGO/G5API/security/code-scanning/104)

In general, to fix this type of issue you should prevent arbitrary, unvalidated user input from being embedded into the URL of outbound HTTP requests. If the host must be fixed (as here), then also constrain any user-controlled path segments to an allow‑listed format (e.g., alphanumeric plus a small set of safe punctuation), and reject or sanitize anything that does not match.

For this specific case in `src/routes/seasons.ts`, the best low-impact fix is to validate `req.body[0].tournament_id` before using it in the Challonge URL. We can enforce that `tournamentId` is either:
- a “simple” Challonge ID/slug (letters, digits, underscore, hyphen), or
- a full Challonge URL whose host ends with `challonge.com`, from which we then extract just the `tournaments/<id>` portion and use only the `<id>` segment in the API call.

This avoids any path traversal or unexpected path structure and ensures `fetch` always calls `https://api.challonge.com/v1/tournaments/<safe-id>.json?...`. Concretely:

1. Right after reading `rawTournamentId` / `tournamentId`, introduce a small validation/normalization function (inline in this file) that:
   - Trims whitespace.
   - If it looks like a URL (`/^https?:\/\//`), uses `new URL()` to parse it, rejects it unless `hostname` ends with `challonge.com`, and extracts the last non-empty path component as the actual tournament identifier.
   - Otherwise, checks that it matches `/^[A-Za-z0-9_-]+$/`; if not, throws a 400-style error.
2. Replace the direct assignment `let tournamentId: string = req.body[0].tournament_id;` with a call to this validator, e.g. `let tournamentId: string = sanitizeChallongeTournamentId(req.body[0].tournament_id);`.
3. Keep the rest of the logic the same so existing functionality (importing from arbitrary Challonge tournaments) continues to work, but with input restricted to safe shapes.

All needed tooling is already available: we can rely on the built-in `URL` class provided by Node; no new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
