### PR TITLE
Potential fix for code scanning alert no. 120: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/v2/demoapi.ts
+++ b/src/routes/v2/demoapi.ts
@@ -19,6 +19,7 @@ import JSZip from "jszip";
  * @const
  */
 import { existsSync, mkdirSync, writeFile } from "fs";
+import path from "path";
 
 /** Config to check demo uploads.
  * @const
@@ -115,6 +116,14 @@ router.post("/", async (req: Request, res: Response) => {
         .status(401)
         .send({ message: "API key, Match ID, or Map Number not provided." });
     }
+
+    // Sanitize the demo filename to prevent path traversal and enforce expected extension.
+    const safeDemoBase: string = path.basename(demoFilename);
+    if (!safeDemoBase.toLowerCase().endsWith(".dem")) {
+      return res.status(400).send({ message: "Invalid demo filename." });
+    }
+    const safeZipName: string = safeDemoBase.replace(/\.dem$/i, ".zip");
+
     // Check if our API key is correct.
     const matchApiCheck: number = await Utils.checkApiKey(apiKey, matchId);
     if (matchApiCheck == 1) {
@@ -144,12 +153,17 @@ router.post("/", async (req: Request, res: Response) => {
       return res.status(401).json({ message: "Demo can no longer be uploaded." });
     }
 
-    zip.file(demoFilename, req.body, { binary: true });
+    zip.file(safeDemoBase, req.body, { binary: true });
     zip
       .generateAsync({ type: "nodebuffer", compression: "DEFLATE" })
       .then((buf) => {
+        const demosRoot = path.resolve("public", "demos");
+        const targetPath = path.resolve(demosRoot, safeZipName);
+        if (!targetPath.startsWith(demosRoot + path.sep)) {
+          throw new Error("Resolved demo path is outside of public/demos");
+        }
         // @ts-ignore
-        writeFile("public/demos/" + demoFilename.replace(".dem", ".zip"), buf, "binary", function (err) {
+        writeFile(targetPath, buf, "binary", function (err) {
           if (err) {
             console.error(err);
             throw err;
@@ -158,7 +172,7 @@ router.post("/", async (req: Request, res: Response) => {
       });
     // Update map stats object to include the link to the demo.
     updateStmt = {
-      demoFile: demoFilename.replace(".dem", ".zip")
+      demoFile: safeZipName
     };
     updateStmt = await db.buildUpdateStatement(updateStmt);
 


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/120](https://github.com/French-CSGO/G5API/security/code-scanning/120)

In general, to fix uncontrolled path usage you must constrain user input before using it in a filesystem path. For this endpoint, the simplest safe behavior that preserves functionality is to treat `Get5-FileName` as a *basename only* (no directories), strip any path separators and other dangerous characters, and then build the final path by concatenating it with the fixed `public/demos` directory. For even stronger safety, you can also normalize the final path with `path.resolve` and ensure it still resides under the intended root directory.

Best concrete fix here:

1. Import Node’s `path` module at the top of `src/routes/v2/demoapi.ts`.
2. As soon as `demoFilename` is available (after header extraction and presence check), derive a sanitized version:
   - Extract only the basename (last path segment) with `path.basename`.
   - Optionally enforce the expected extension (`.dem`), rejecting others.
   - Reject empty results after sanitization.
3. Use this sanitized name everywhere that currently uses `demoFilename` for filesystem purposes:
   - As the internal filename inside the ZIP (`zip.file(...)`).
   - When constructing the `writeFile` target path.
   - When storing the filename in `updateStmt.demoFile`.
4. When constructing the path for `writeFile`, use `path.join` to combine the fixed root (`public/demos`) with the sanitized filename, and optionally verify that the resolved path stays under `public/demos` if you want defense‑in‑depth.

This keeps existing behavior (client controls the filename and it’s stored in the DB) but removes directory traversal and arbitrary path issues. All changes are confined to `src/routes/v2/demoapi.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
