### PR TITLE
Potential fix for code scanning alert no. 117: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/v2/backupapi.ts
+++ b/src/routes/v2/backupapi.ts
@@ -26,6 +26,7 @@ import { RowDataPacket } from "mysql2";
  * Global Server Sent Emitter class for real time data.
  */
 import { existsSync, mkdirSync, writeFile } from "fs";
+import path from "path";
 
 /** Express module
  * @const
@@ -110,11 +111,24 @@ router.post("/", async (req: Request, res: Response) => {
       });
       return;
     }
-    if (!existsSync(`public/backups/${matchId}/`))
-      mkdirSync(`public/backups/${matchId}/`, { recursive: true });
+    const backupRoot = path.resolve("public", "backups");
+    const matchDir = path.resolve(backupRoot, matchId);
+    if (!(matchDir === backupRoot || matchDir.startsWith(backupRoot + path.sep))) {
+      res.status(403).send({ message: "Invalid match ID path." });
+      return;
+    }
+
+    if (!existsSync(matchDir)) {
+      mkdirSync(matchDir, { recursive: true });
+    }
+
+    const backupFilePath = path.join(
+      matchDir,
+      `get5_backup_match${matchId}_map${mapNumber}_round${roundNumber}.cfg`
+    );
 
     writeFile(
-      `public/backups/${matchId}/get5_backup_match${matchId}_map${mapNumber}_round${roundNumber}.cfg`,
+      backupFilePath,
       req.body,
       function (err) {
         if (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/117](https://github.com/French-CSGO/G5API/security/code-scanning/117)

In general, file paths derived from user input must be constrained so they cannot escape a designated root directory. This is typically done by resolving the final path against a fixed root with `path.resolve` (and optionally `fs.realpathSync`) and then verifying that the resulting absolute path still lies under that root. Reject or error out if it does not.

Here, `matchId` is only used to construct a subdirectory and filename under `public/backups/`. The safest change without altering functionality is:

1. Define a constant root backup directory, e.g. `const BACKUP_ROOT = path.resolve("public/backups");`.
2. Build the intended directory and file paths with `path.join(BACKUP_ROOT, matchId)` and `path.join(dirPath, filename)`.
3. Normalize/resolve these with `path.resolve` and ensure they remain under `BACKUP_ROOT` by checking `startsWith(BACKUP_ROOT + path.sep)` (or equality to `BACKUP_ROOT` if needed).
4. If the check fails, return `403` or `400` instead of touching the filesystem.

We must also import Node’s `path` module in this file and replace the direct template-literal paths in `existsSync`, `mkdirSync`, and `writeFile` with the validated paths. No changes to external behavior (directory structure and filenames) are needed; we’re just constructing them more safely and rejecting malicious `matchId` values.

Concretely, in `src/routes/v2/backupapi.ts`:

- Add `import path from "path";`.
- Inside the POST handler, after the API key checks and before `existsSync`, introduce:
  - `const backupRoot = path.resolve("public", "backups");`
  - `const matchDir = path.resolve(backupRoot, matchId);`
  - A guard that ensures `matchDir` starts with `backupRoot + path.sep` or equals `backupRoot`.
- Replace the `existsSync` / `mkdirSync` and `writeFile` calls to use `matchDir` and a `backupFilePath` derived via `path.join`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
