### PR TITLE
Potential fix for code scanning alert no. 116: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -1641,7 +1641,12 @@ router.put(
   basicRateLimit,
   async (req, res, next) => {
     try {
-      let matchID: string = req.params.match_id;
+      const matchIdParam: string = req.params.match_id;
+      const matchIDNum: number = parseInt(matchIdParam, 10);
+      if (!Number.isInteger(matchIDNum) || matchIDNum <= 0) {
+        res.status(400).json({ message: "Invalid match_id" });
+        return;
+      }
       let mapNumber: number = parseInt(req.params.map_number);
       // This is required since we're sending an octet stream.
       let apiKey: string = keyCheck(req);
@@ -1649,7 +1654,7 @@ router.put(
       // Database calls.
       let sql: string = "SELECT * FROM `match` WHERE id = ?";
       let matchFinalized: boolean = true;
-      const matchValues: RowDataPacket[] = await db.query(sql, [matchID]);
+      const matchValues: RowDataPacket[] = await db.query(sql, [matchIDNum]);
 
       if (
         matchValues[0].end_time == null &&
@@ -1659,6 +1664,7 @@ router.put(
       // Throw error if wrong key. Match finish doesn't matter.
       await check_api_key(matchValues[0].api_key, apiKey, matchFinalized);
 
+      const matchID: string = matchIDNum.toString();
       if (!existsSync(`public/backups/${matchID}/`)) mkdirSync(`public/backups/${matchID}/`, {recursive: true});
 
       writeFile(


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/116](https://github.com/French-CSGO/G5API/security/code-scanning/116)

To fix this, ensure the portion of the path derived from user input is safe. Since `match_id` is documented as an integer, the least invasive and most robust approach is to validate it as a positive integer and use a normalized string representation (e.g., `parseInt` and `Number.isInteger` checks). This both prevents traversal sequences like `../` and enforces the intended data type without changing existing behavior for legitimate numeric IDs.

Concretely in `src/routes/legacy/api.ts` within this route:

- Parse `req.params.match_id` to an integer, verify that it is a finite, positive integer, and reject the request (HTTP 400) if it is not.
- Use the validated integer when:
  - Querying the database.
  - Constructing filesystem paths for `existsSync`, `mkdirSync`, and `writeFile`.
- Keep other logic intact so functionality remains the same for valid IDs.

We do not need new imports; we can use built‑in `Number.isInteger`. All changes will be directly around lines 1644–1666 where `matchID` is derived and the paths are constructed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
