### PR TITLE
Potential fix for code scanning alert no. 3: Server crash

### DIFF
--- a/src/routes/v2/backupapi.ts
+++ b/src/routes/v2/backupapi.ts
@@ -150,11 +150,17 @@ router.post("/", backupRateLimiter, async (req: Request, res: Response) => {
       function (err) {
         if (err) {
           console.error(err);
-          throw err;
+          // Failed to write the backup file; respond with an error instead of throwing.
+          if (!res.headersSent) {
+            res.status(500).send({ message: "Failed to write backup file." });
+          }
+          return;
+        }
+        if (!res.headersSent) {
+          res.status(200).send({ message: "Success" });
         }
       }
     );
-    res.status(200).send({ message: "Success" });
   } catch (error) {
     console.error(error);
     res.status(500).send({ message: error });


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/3](https://github.com/French-CSGO/G5API/security/code-scanning/3)

In general, the problem should be fixed by ensuring that errors in asynchronous callbacks are handled by responding to the client or logging, rather than by throwing exceptions that escape the callback. For callback-based APIs like `fs.writeFile`, this means replacing `throw` with appropriate error handling logic inside the callback. Alternatively, converting to `async/await` via `fs.promises` and wrapping the `await` in the surrounding `try/catch` is also safe.

The minimal change that preserves existing functionality is to modify the `writeFile` callback so that, on error, it logs the error and sends a 500 response to the client, instead of throwing. Since we already have a `try/catch` around the main body and a `res.status(200).send({ message: "Success" });` after `writeFile`, we should also ensure that the success response is only sent after `writeFile` completes successfully. That means moving the success response into the callback, and adding an error response path there. Concretely, in `src/routes/v2/backupapi.ts` around lines 147–157, replace the call to `writeFile` and the subsequent success response with a version where the callback handles both error and success, without throwing. No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
