### PR TITLE
Potential fix for code scanning alert no. 126: Missing rate limiting

### DIFF
--- a/src/routes/v2/backupapi.ts
+++ b/src/routes/v2/backupapi.ts
@@ -27,6 +27,7 @@ import { RowDataPacket } from "mysql2";
  */
 import { existsSync, mkdirSync, writeFile } from "fs";
 import path from "path";
+import rateLimit from "express-rate-limit";
 
 /** Express module
  * @const
@@ -36,7 +37,7 @@ const router: Router = Router();
 // Rate limiter specific to backup uploads to mitigate disk I/O abuse.
 const backupRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 999999, // limit each IP to 100 backup requests per windowMs
+  max: 100, // limit each IP to 100 backup requests per windowMs
   standardHeaders: true,
   legacyHeaders: false
 });


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/126](https://github.com/French-CSGO/G5API/security/code-scanning/126)

To fix the problem, the route should be protected by a rate-limiting middleware that bounds how many backup uploads a client can trigger over a period of time. This is commonly done with a library such as `express-rate-limit`. The best fix here is to (1) import `express-rate-limit`, (2) configure a sane per-IP limit for this specific backup endpoint, and (3) ensure the middleware is wired correctly into the `router.post` call.

Concretely in `src/routes/v2/backupapi.ts`:

- Add an import for `rateLimit` from `express-rate-limit` at the top of the file without modifying existing imports.
- Define `backupRateLimiter` using `rateLimit({ windowMs, max, standardHeaders, legacyHeaders })`. The current `max: 999999` is effectively useless as a limit; change it to a realistic bound (for example, `max: 100` per 15 minutes), matching the comment and CodeQL’s guidance.
- Keep the existing `router.post("/", backupRateLimiter, async ...)` signature so the limiter is actually applied to the backup route.
- No other functionality of the handler needs to change; we’re only adding the missing middleware and correcting its configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
