### PR TITLE
Potential fix for code scanning alert no. 109: Missing CSRF middleware

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -11,6 +11,7 @@ import logger from "morgan";
 import morgan from "morgan";
 import { createClient } from "redis";
 import swaggerJSDoc from "swagger-jsdoc";
+import { csrf } from "lusca";
 
 import { serve, setup } from "swagger-ui-express";
 
@@ -48,6 +49,7 @@ app.use(express.raw({ type: "application/octet-stream", limit: "2gb" }));
 app.use(express.json({ limit: "512kb" }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+app.use(csrf());
 app.use("/demo", express.static("public/demos"));
 app.use("/backups", express.static("public/backups"));
 app.use("/static/img/logos", express.static("public/img/logos"));

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",
     "tmi.js": "^1.8.5",
-    "ts3-nodejs-library": "^3.5.0"
+    "ts3-nodejs-library": "^3.5.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@types/aes-js": "^3.1.1",


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/109](https://github.com/French-CSGO/G5API/security/code-scanning/109)

In general, for an Express app that uses cookies/sessions for authentication, CSRF protection should be enforced for state‑changing routes (typically POST/PUT/PATCH/DELETE). The usual fix is to add a CSRF middleware (for example `lusca.csrf()` as recommended, or `csurf`) after cookie/session middleware is configured, and before the routes that need protection. This middleware ensures that incoming modifying requests contain a valid, unpredictable token that matches what was provided to the client.

For this codebase, the least-invasive, best fix consistent with the recommendation is:

1. Import `csrf` from `lusca` at the top of `app.ts`.
2. Add `app.use(csrf());` after `cookieParser()` and session initialization (session setup is not shown, but we’ll place CSRF as soon as possible after `cookieParser()` while staying within the shown snippet). This will apply CSRF protection globally to subsequent routes, including `/login` and `/register`, satisfying CodeQL for all variants referencing request handlers downstream of `cookieParser()`.
3. Because we are not allowed to change code outside the shown snippets, we will:
   - Add the `lusca` import to the imports block.
   - Insert `app.use(csrf());` immediately after `app.use(cookieParser());` as that is within the visible region and before the request handlers indicated by CodeQL.

This preserves existing functionality as much as possible while adding a standard CSRF defense. It might require client updates to send the CSRF token, but that is unavoidable for correct CSRF protection and does not change server semantics besides rejecting missing/invalid-token requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
