### PR TITLE
Potential fix for code scanning alert no. 127: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/v2/backupapi.ts
+++ b/src/routes/v2/backupapi.ts
@@ -121,6 +121,15 @@ router.post("/", backupRateLimiter, async (req: Request, res: Response) => {
       });
       return;
     }
+    // Validate mapNumber and roundNumber to ensure they are simple, safe values.
+    // Allow only up to three digits for each; adjust the pattern if a wider range is required.
+    const numberPattern = /^[0-9]{1,3}$/;
+    if (!numberPattern.test(mapNumber) || !numberPattern.test(roundNumber)) {
+      res.status(400).send({
+        message: "Invalid map or round number format."
+      });
+      return;
+    }
     // Check if our API key is correct.
     const matchApiCheck: number = await Utils.checkApiKey(apiKey, matchId);
     if (matchApiCheck == 1 || matchApiCheck == 2) {
@@ -144,9 +153,15 @@ router.post("/", backupRateLimiter, async (req: Request, res: Response) => {
       matchDir,
       `get5_backup_match${matchId}_map${mapNumber}_round${roundNumber}.cfg`
     );
+    // Normalize and verify the final backup file path to ensure it remains within matchDir.
+    const resolvedBackupFilePath = path.resolve(matchDir, path.basename(backupFilePath));
+    if (!(resolvedBackupFilePath === matchDir || resolvedBackupFilePath.startsWith(matchDir + path.sep))) {
+      res.status(403).send({ message: "Invalid backup file path." });
+      return;
+    }
 
     writeFile(
-      backupFilePath,
+      resolvedBackupFilePath,
       req.body,
       function (err) {
         if (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/127](https://github.com/French-CSGO/G5API/security/code-scanning/127)

In general, to fix uncontrolled data in path expressions you must ensure that any user‑provided values used in directory names or filenames are strictly validated or normalized before use, and that the final computed path is checked to remain within an expected root directory. Here, the directory component (`matchDir`) is already constrained to `backupRoot` using `path.resolve` plus a prefix check, and `matchId` is validated with a tight regex. The missing pieces are: (1) validating `mapNumber` and `roundNumber` to allow only simple numeric values or a similarly restricted pattern, and (2) optionally normalizing and revalidating the final `backupFilePath` to ensure that, even if something slipped through, the written file still resides under `matchDir`.

The single best way to fix the problem without changing observable functionality is:

1. Add validation for `mapNumber` and `roundNumber` right after they are read and the basic presence check is done. For example, require them to match `/^[0-9]{1,3}$/` (or a similarly constrained pattern), returning HTTP 400 if invalid. This prevents injection of path separators or other special characters into the filename.
2. After constructing `backupFilePath` with `path.join`, call `path.resolve(matchDir, path.basename(backupFilePath))` (or simply `path.resolve(matchDir, filename)`) to normalize it, and then verify that the resolved path is equal to or under `matchDir` using the same prefix pattern as used for `matchDir` vs `backupRoot`. If this check fails, return 403 instead of writing the file.
3. Use only existing imports (`path`) and avoid introducing new dependencies; the current standard library functions are sufficient.

All necessary edits are confined to `src/routes/v2/backupapi.ts` within the existing `router.post("/", ...)` handler:

- After the presence check for headers (around lines 109–114), add regex validation for `mapNumber` and `roundNumber` and respond with 400 if they are invalid.
- After constructing `backupFilePath` (around lines 143–146), resolve and re‑validate `backupFilePath` to ensure it remains inside `matchDir`, and if not, respond with 403.

No new imports or helper methods are required beyond what’s already in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
