### PR TITLE
Potential fix for code scanning alert no. 128: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/v2/backupapi.ts
+++ b/src/routes/v2/backupapi.ts
@@ -140,6 +140,7 @@ router.post("/", backupRateLimiter, async (req: Request, res: Response) => {
     }
     const backupRoot = path.resolve("public", "backups");
     const matchDir = path.resolve(backupRoot, matchId);
+    // Ensure the per-match directory is inside the backup root.
     if (!(matchDir === backupRoot || matchDir.startsWith(backupRoot + path.sep))) {
       res.status(403).send({ message: "Invalid match ID path." });
       return;
@@ -153,9 +154,9 @@ router.post("/", backupRateLimiter, async (req: Request, res: Response) => {
       matchDir,
       `get5_backup_match${matchId}_map${mapNumber}_round${roundNumber}.cfg`
     );
-    // Normalize and verify the final backup file path to ensure it remains within matchDir.
-    const resolvedBackupFilePath = path.resolve(matchDir, path.basename(backupFilePath));
-    if (!(resolvedBackupFilePath === matchDir || resolvedBackupFilePath.startsWith(matchDir + path.sep))) {
+    // Normalize and verify the final backup file path to ensure it remains within the backup root.
+    const resolvedBackupFilePath = path.resolve(backupFilePath);
+    if (!(resolvedBackupFilePath === backupRoot || resolvedBackupFilePath.startsWith(backupRoot + path.sep))) {
       res.status(403).send({ message: "Invalid backup file path." });
       return;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/128](https://github.com/French-CSGO/G5API/security/code-scanning/128)

In general, to fix uncontrolled path usage, normalize the path relative to a trusted root directory and then verify that the normalized path is still within that root. Alternatively, restrict user-controlled values to *identifiers* (not paths) and use them only in safe positions like directory names or filenames, while keeping the path structure itself hard-coded.

For this specific code, the safest and simplest approach without changing functionality is:

1. Treat `backupRoot` (`public/backups`) as the only root.
2. Keep `matchId`, `mapNumber`, and `roundNumber` as identifiers (we already validate them with strict regexes).
3. Construct a filename string that is entirely under our control except for these validated identifiers.
4. Combine everything with `path.join(backupRoot, matchId, filename)` and then:
   - Use `path.resolve` to normalize the final path.
   - Verify that this final path starts with the canonical `backupRoot` path (plus separator).
5. Remove the incorrect check comparing a file path to `matchDir`.

This preserves behavior (still writes backups under `public/backups/<matchId>/...`) but uses one clear, canonical containment check at the root level. It also keeps the data flow pattern simple enough that CodeQL can see the validation and containment.

Concretely in `src/routes/v2/backupapi.ts`:

- Keep the existing regex validation for `matchId`, `mapNumber`, and `roundNumber`.
- Define `backupRoot` with `path.resolve("public", "backups")` as already done.
- Remove `resolvedBackupFilePath` and the associated check.
- Instead, after constructing `backupFilePath` with `path.join`, call `path.resolve(backupFilePath)` to get `resolvedBackupFilePath`.
- Check that `resolvedBackupFilePath` starts with `backupRoot + path.sep` (or equals `backupRoot` if we ever allowed directories).
- Use `resolvedBackupFilePath` directly in `writeFile`.

No new imports are needed; we already import `path` and `fs` helpers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
