### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/migrations/development/20210201015955-get5db.js
+++ b/migrations/development/20210201015955-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-var async = require('async');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.


### PR DESCRIPTION
In general, unused variables should be removed to avoid confusion and possible hints of incomplete implementations. Here, the best fix is to delete the unused `async` require declaration, since the module is not used anywhere in this migration.

Concretely:
- In `migrations/development/20210201015955-get5db.js`, remove the line `var async = require('async');`.
- No other code changes are necessary; the `exports.setup`, `exports.up`, and `exports.down` functions remain as they are.
- No additional imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._