### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/migrations/development/20220211220305-get5db.js
+++ b/migrations/development/20220211220305-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-var async = require('async');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.


### PR DESCRIPTION
To fix the problem, remove the unused variable definition so that the file no longer requires `async` if it is not used. This resolves the CodeQL warning and slightly reduces load time and dependency surface.

The best minimal fix is to delete line 6, `var async = require('async');`, and leave the rest of the migration unchanged. No additional imports, methods, or definitions are required, and no other lines need to be updated because nothing references `async`.

Concretely, in `migrations/development/20220211220305-get5db.js`, edit the top of the file to remove the `async` require, keeping the `'use strict';` directive and the `dbm`, `type`, and `seed` variable declarations intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._