### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/migrations/development/20201118184033-get5db.js
+++ b/migrations/development/20201118184033-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.

--- a/migrations/development/20201118184033-get5db.js
+++ b/migrations/development/20201118184033-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-var async = require('async');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.


### PR DESCRIPTION
To fix the problem, remove the unused `async` variable and its corresponding `require('async')` call. This eliminates the dead code and resolves the CodeQL warning without affecting functionality, since nothing in the snippet depends on `async`.

Concretely, in `migrations/development/20201118184033-get5db.js`, delete line 6 (`var async = require('async');`). No other lines need to change, and no additional imports or definitions are required. The migration continues to work exactly as before because it never used `async`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._