### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/migrations/production/20201118184033-get5db.js
+++ b/migrations/production/20201118184033-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-/**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */

--- a/migrations/production/20201118184033-get5db.js
+++ b/migrations/production/20201118184033-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.

--- a/migrations/production/20201118184033-get5db.js
+++ b/migrations/production/20201118184033-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-var async = require('async');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.


### PR DESCRIPTION
To fix the problem, remove the unused `async` variable and its `require('async')` import from the migration file. This eliminates the dead code without changing any existing functionality, since `async` is never referenced.

Concretely, in `migrations/production/20201118184033-get5db.js`, delete line 6 that declares and initializes `async`. No other changes are required: no additional imports, methods, or definitions are needed, and the remaining code will behave identically.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._