### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/migrations/test/20210124162658-get5db.js
+++ b/migrations/test/20210124162658-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-/**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */

--- a/migrations/test/20210124162658-get5db.js
+++ b/migrations/test/20210124162658-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-  * This enables us to not have to rely on NODE_PATH.
   */
 exports.setup = function(options, seedLink) {
   dbm = options.dbmigrate;

--- a/migrations/test/20210124162658-get5db.js
+++ b/migrations/test/20210124162658-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.

--- a/migrations/test/20210124162658-get5db.js
+++ b/migrations/test/20210124162658-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-var async = require('async');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.

--- a/migrations/test/20210124162658-get5db.js
+++ b/migrations/test/20210124162658-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-  * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
 exports.setup = function(options, seedLink) {


### PR DESCRIPTION
In general, to fix an "unused variable" warning, either remove the unused declaration or start using the variable in a meaningful way. Here, the best fix without changing functionality is to remove the unused `async` variable and its `require('async')` statement entirely, since the code already uses promise chaining and does not need the `async` library.

Concretely, in `migrations/test/20210124162658-get5db.js`, delete the line that declares and initializes `async`:

- Remove line 6: `var async = require('async');`

No other changes are required; there are no references to `async` elsewhere in the snippet, and no imports or definitions need to be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._