### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/migrations/test/20210201015955-get5db.js
+++ b/migrations/test/20210201015955-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.

--- a/migrations/test/20210201015955-get5db.js
+++ b/migrations/test/20210201015955-get5db.js
@@ -3,7 +3,6 @@
 var dbm;
 var type;
 var seed;
-var async = require('async');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.


### PR DESCRIPTION
To fix the problem, remove the unused `async` variable and its `require('async')` assignment. This eliminates the dead code without changing functionality, since nothing in the file depends on `async`.

Concretely, in `migrations/test/20210201015955-get5db.js`, delete line 6 (`var async = require('async');`). No other changes are required: no references to `async` exist, and no replacements are needed. The rest of the migration (the `setup`, `up`, `down`, and `_meta` exports) remain untouched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._