### PR TITLE
Potential fix for code scanning alert no. 109: Missing CSRF middleware

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -10,7 +10,7 @@ import createError from "http-errors";
 import morgan from "morgan";
 import { createClient } from "redis";
 import swaggerJSDoc from "swagger-jsdoc";
-
+import { csrf } from "lusca";
 import { serve, setup } from "swagger-ui-express";
 
 // Route Files
@@ -47,6 +47,7 @@ app.use(express.raw({ type: "application/octet-stream", limit: "2gb" }));
 app.use(express.json({ limit: "512kb" }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+app.use(csrf());
 app.use("/demo", express.static("public/demos"));
 app.use("/backups", express.static("public/backups"));
 app.use("/static/img/logos", express.static("public/img/logos"));


### PR DESCRIPTION
Potential fix for [https://github.com/French-CSGO/G5API/security/code-scanning/109](https://github.com/French-CSGO/G5API/security/code-scanning/109)

In general, to fix this kind of issue you should ensure that any state‑changing routes (especially those using cookie‑based authentication or sessions) are protected by CSRF middleware. In Express this is usually done by adding a CSRF middleware such as `lusca.csrf()` or `csurf()` after cookie/session middleware but before route handlers. The middleware generates or validates a per‑session token that must be supplied by the client, preventing cross‑site requests from succeeding.

For this codebase, the least intrusive fix that addresses all flagged variants is:

1. Import a CSRF middleware, following the recommendation, e.g. `import { csrf } from "lusca";` (ESM form of `require('lusca').csrf`).
2. Register the CSRF middleware after `cookieParser()` (and after `express-session` setup if it appears in the omitted section) and before defining the `/login` and `/register` (and other) handlers. Because we only see `cookieParser()` and no session setup in the shown snippet, we will at least ensure CSRF is installed immediately after cookies are parsed; this is consistent with lusca’s own usage pattern when sessions are present.
3. To avoid breaking existing functionality for non‑state‑changing or public routes, we can initially apply CSRF globally, but in many real deployments you’d selectively disable it for specific routes (e.g., pure APIs, webhooks). We must not assume such exclusions here, so we apply it generally.

Concretely in `app.ts`:

- Add a new import at the top for `lusca`’s `csrf` helper.
- Add `app.use(csrf());` right after `app.use(cookieParser());` on line 49. This ensures every subsequent route, including `/login` and `/register`, requires a valid CSRF token, satisfying CodeQL’s requirement that cookie‑based handlers be behind CSRF middleware.
- No other changes to the route handlers are required in this task; integrating CSRF token generation into templates or responses would be a follow‑up concern outside the snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
