### PR TITLE
feat: Challonge v2 — API v2.1 migration, multi-bracket, live scores, mark as underway

### DIFF
--- a/migrations/development/20260410120000-match-tournament-ids.js
+++ b/migrations/development/20260410120000-match-tournament-ids.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(
+    `ALTER TABLE \`match\`
+      ADD COLUMN toornament_id VARCHAR(64) DEFAULT NULL AFTER season_id,
+      ADD COLUMN challonge_id  BIGINT      DEFAULT NULL AFTER toornament_id;`
+  );
+};
+
+exports.down = function (db) {
+  return db.runSql(
+    `ALTER TABLE \`match\`
+      DROP COLUMN challonge_id,
+      DROP COLUMN toornament_id;`
+  );
+};
+
+exports._meta = {
+  version: 35,
+};

--- a/migrations/development/20260410130000-season-challonge-tournament.js
+++ b/migrations/development/20260410130000-season-challonge-tournament.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(
+    `CREATE TABLE IF NOT EXISTS season_challonge_tournament (
+      id            INT NOT NULL AUTO_INCREMENT,
+      season_id     INT NOT NULL,
+      challonge_slug VARCHAR(100) NOT NULL,
+      label         VARCHAR(60)  NOT NULL DEFAULT 'Main',
+      display_order INT          NOT NULL DEFAULT 0,
+      PRIMARY KEY (id),
+      UNIQUE KEY uq_season_slug (season_id, challonge_slug),
+      CONSTRAINT fk_sct_season FOREIGN KEY (season_id)
+        REFERENCES season (id) ON DELETE CASCADE ON UPDATE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`
+  );
+};
+
+exports.down = function (db) {
+  return db.runSql("DROP TABLE IF EXISTS season_challonge_tournament;");
+};
+
+exports._meta = {
+  version: 36,
+};

--- a/migrations/production/20260410120000-match-tournament-ids.js
+++ b/migrations/production/20260410120000-match-tournament-ids.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(
+    `ALTER TABLE \`match\`
+      ADD COLUMN toornament_id VARCHAR(64) DEFAULT NULL AFTER season_id,
+      ADD COLUMN challonge_id  BIGINT      DEFAULT NULL AFTER toornament_id;`
+  );
+};
+
+exports.down = function (db) {
+  return db.runSql(
+    `ALTER TABLE \`match\`
+      DROP COLUMN challonge_id,
+      DROP COLUMN toornament_id;`
+  );
+};
+
+exports._meta = {
+  version: 35,
+};

--- a/migrations/production/20260410130000-season-challonge-tournament.js
+++ b/migrations/production/20260410130000-season-challonge-tournament.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(
+    `CREATE TABLE IF NOT EXISTS season_challonge_tournament (
+      id            INT NOT NULL AUTO_INCREMENT,
+      season_id     INT NOT NULL,
+      challonge_slug VARCHAR(100) NOT NULL,
+      label         VARCHAR(60)  NOT NULL DEFAULT 'Main',
+      display_order INT          NOT NULL DEFAULT 0,
+      PRIMARY KEY (id),
+      UNIQUE KEY uq_season_slug (season_id, challonge_slug),
+      CONSTRAINT fk_sct_season FOREIGN KEY (season_id)
+        REFERENCES season (id) ON DELETE CASCADE ON UPDATE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`
+  );
+};
+
+exports.down = function (db) {
+  return db.runSql("DROP TABLE IF EXISTS season_challonge_tournament;");
+};
+
+exports._meta = {
+  version: 36,
+};

--- a/migrations/test/20260410120000-match-tournament-ids.js
+++ b/migrations/test/20260410120000-match-tournament-ids.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(
+    `ALTER TABLE \`match\`
+      ADD COLUMN toornament_id VARCHAR(64) DEFAULT NULL AFTER season_id,
+      ADD COLUMN challonge_id  BIGINT      DEFAULT NULL AFTER toornament_id;`
+  );
+};
+
+exports.down = function (db) {
+  return db.runSql(
+    `ALTER TABLE \`match\`
+      DROP COLUMN challonge_id,
+      DROP COLUMN toornament_id;`
+  );
+};
+
+exports._meta = {
+  version: 35,
+};

--- a/migrations/test/20260410130000-season-challonge-tournament.js
+++ b/migrations/test/20260410130000-season-challonge-tournament.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(
+    `CREATE TABLE IF NOT EXISTS season_challonge_tournament (
+      id            INT NOT NULL AUTO_INCREMENT,
+      season_id     INT NOT NULL,
+      challonge_slug VARCHAR(100) NOT NULL,
+      label         VARCHAR(60)  NOT NULL DEFAULT 'Main',
+      display_order INT          NOT NULL DEFAULT 0,
+      PRIMARY KEY (id),
+      UNIQUE KEY uq_season_slug (season_id, challonge_slug),
+      CONSTRAINT fk_sct_season FOREIGN KEY (season_id)
+        REFERENCES season (id) ON DELETE CASCADE ON UPDATE RESTRICT
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`
+  );
+};
+
+exports.down = function (db) {
+  return db.runSql("DROP TABLE IF EXISTS season_challonge_tournament;");
+};
+
+exports._meta = {
+  version: 36,
+};

--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -12,6 +12,14 @@ const router = Router();
  * @const
  */
 import {db} from "../../services/db.js";
+import {
+  CHALLONGE_V2_BASE,
+  challongeHeaders,
+  parseV2Match,
+  buildMatchPutBody,
+  buildTournamentStateBody
+} from "../../utility/challongeV2.js";
+import { getSetting } from "../../services/settings.js";
 
 /** Rate limit includes.
  * @const
@@ -1726,81 +1734,69 @@ async function update_challonge_match(match_id: string | null, season_id: number
     const team1ChallongeId: RowDataPacket[] = await db.query(sql, [team1_id]);
     const team2ChallongeId: RowDataPacket[] = await db.query(sql, [team2_id]);
 
-    // Grab API key.
-    sql = "SELECT challonge_api_key FROM user WHERE id = ?";
-    const challongeAPIKey: RowDataPacket[] = await db.query(sql, [seasonInfo[0].user_id]);
-    let decryptedKey: string | null | undefined = Utils.decrypt(challongeAPIKey[0].challonge_api_key);
-    // Get info of the current open match with the two IDs.
-    let challongeResponse: Response = await fetch(
-      "https://api.challonge.com/v1/tournaments/" +
-      seasonInfo[0].challonge_url +
-      "/matches.json?api_key=" + decryptedKey +
-      "&state=open&participant_id=" +
-      team1ChallongeId[0].challonge_team_id +
-      "&participant_id=" +
-      team2ChallongeId[0].challonge_team_id);
-    // TODO: Use typings for challonge API calls.
-    let challongeData: any[] = await challongeResponse.json() as any[];
-    if (challongeData) {
+    // Récupérer la clé API Challonge depuis les paramètres système
+    const decryptedKey = getSetting("challonge.apiKey");
+    if (!decryptedKey) return;
+
+    const t1cid: number = team1ChallongeId[0].challonge_team_id;
+    const t2cid: number = team2ChallongeId[0].challonge_team_id;
+    const slug: string = seasonInfo[0].challonge_url;
+    const cHeaders = challongeHeaders(decryptedKey);
+
+    // v2.1 — récupère tous les matchs ouverts et filtre par participants
+    const challongeResponse = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
+      { headers: cHeaders }
+    );
+    const respBody: any = await challongeResponse.json();
+    const allMatches: any[] = Array.isArray(respBody?.data) ? respBody.data.map(parseV2Match) : [];
+    const matchData = allMatches.find(m =>
+      (m.player1_id === t1cid && m.player2_id === t2cid) ||
+      (m.player2_id === t1cid && m.player1_id === t2cid)
+    );
+
+    if (matchData) {
       if (num_maps == 1) {
-        // Submit the map stats scores instead.
         sql = "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ?";
       } else {
         sql = "SELECT team1_score, team2_score FROM `match` WHERE id = ?";
       }
       const mapStats: RowDataPacket[] = await db.query(sql, [match_id]);
-      // Admins may just make a match that has teams swapped. This is okay as we can change what we
-      // report to Challonge.
-      team1Score = challongeData[0].match.player1_id == team1ChallongeId[0].challonge_team_id
+      // Admins may just make a match that has teams swapped.
+      team1Score = matchData.player1_id === t1cid
         ? mapStats[0].team1_score
         : mapStats[0].team2_score;
-      team2Score = challongeData[0].match.player2_id == team2ChallongeId[0].challonge_team_id
+      team2Score = matchData.player2_id === t2cid
         ? mapStats[0].team2_score
         : mapStats[0].team1_score;
-      // Build the PUT body.
-      let putBody = {
-        api_key: decryptedKey,
-        match: {
-          scores_csv: `${team1Score}-${team2Score}`,
-          winner_id: winner === "team1"
-            ? team1ChallongeId[0].challonge_team_id
-            : team2ChallongeId[0].challonge_team_id
-        }
-      };
-      // If we're just updating the score, remove this.
-      if (winner === null) {
-        delete putBody.match.winner_id;
-      }
+
+      // v2.1 — PUT score update
       await fetch(
-        "https://api.challonge.com/v1/tournaments/" +
-        seasonInfo[0].challonge_url +
-        "/matches/" +
-        challongeData[0].match.id +
-        ".json", {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(putBody)
-      });
-      // Check and see if any matches remain, if not, finalize the tournament.
-      challongeResponse = await fetch(
-        "https://api.challonge.com/v1/tournaments/" +
-        seasonInfo[0].challonge_url +
-        "/matches.json?api_key=" + decryptedKey +
-        "&state=open"
+        `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}.json`,
+        {
+          method: "PUT",
+          headers: cHeaders,
+          body: JSON.stringify(buildMatchPutBody(t1cid, t2cid, team1Score, team2Score, winner))
+        }
       );
-      challongeData = await challongeResponse.json() as any[];
-      if (!challongeData) {
+
+      // Check and see if any matches remain, if not, finalize the tournament.
+      const openResp = await fetch(
+        `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
+        { headers: cHeaders }
+      );
+      const openBody: any = await openResp.json();
+      const openMatches: any[] = Array.isArray(openBody?.data) ? openBody.data : [];
+      if (openMatches.length === 0) {
+        // v2.1 — finalize via change_state
         await fetch(
-          "https://api.challonge.com/v1/tournaments/" +
-          seasonInfo[0].challonge_url +
-          "finalize.json?api_key=" + decryptedKey,
+          `${CHALLONGE_V2_BASE}/tournaments/${slug}/change_state.json`,
           {
-            method: 'POST'
+            method: "PUT",
+            headers: cHeaders,
+            body: JSON.stringify(buildTournamentStateBody("finalize"))
           }
         );
-        // If we are the last map, let's close off the season as well.
         sql = "UPDATE season SET end_date = ? WHERE id = ?";
         await db.query(sql, [new Date().toISOString().slice(0, 19).replace("T", " "), seasonInfo[0].id]);
         GlobalEmitter.emit("seasonUpdate");

--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -1806,17 +1806,26 @@ async function update_challonge_match(match_id: string | null, season_id: number
 /** Marks a Challonge match as underway (called when the first map starts). */
 async function mark_challonge_underway(match_id: string, season_id: number, team1_id: number, team2_id: number): Promise<void> {
   const seasonInfo: RowDataPacket[] = await db.query(
-    "SELECT id, challonge_url FROM season WHERE id = ?",
+    "SELECT id, challonge_url, is_challonge FROM season WHERE id = ?",
     [season_id]
   );
-  if (!seasonInfo.length || !seasonInfo[0].challonge_url) return;
-  if (seasonInfo[0].challonge_url.startsWith("t:")) return; // toornament
+  if (!seasonInfo.length || !seasonInfo[0].is_challonge) return;
+  if (seasonInfo[0].challonge_url?.startsWith("t:")) return; // toornament
 
   const decryptedKey = getSetting("challonge.apiKey");
   if (!decryptedKey) return;
 
   const cHeaders = challongeHeaders(decryptedKey);
-  const slug: string = seasonInfo[0].challonge_url;
+
+  // Cherche dans tous les slugs de la saison (brackets multiples inclus)
+  const tournaments: RowDataPacket[] = await db.query(
+    "SELECT challonge_slug FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC",
+    [season_id]
+  );
+  const slugList: string[] = tournaments.length > 0
+    ? tournaments.map(t => t.challonge_slug as string)
+    : (seasonInfo[0].challonge_url ? [seasonInfo[0].challonge_url as string] : []);
+  if (!slugList.length) return;
 
   const t1Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team1_id]);
   const t2Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team2_id]);
@@ -1824,20 +1833,24 @@ async function mark_challonge_underway(match_id: string, season_id: number, team
   const t2cid: number = t2Row[0]?.challonge_team_id;
   if (!t1cid || !t2cid) return;
 
-  const resp = await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`, { headers: cHeaders });
-  const body: any = await resp.json();
-  const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
-  const matchData = allMatches.find(m =>
-    (m.player1_id === t1cid && m.player2_id === t2cid) ||
-    (m.player2_id === t1cid && m.player1_id === t2cid)
-  );
-  if (!matchData) return;
+  for (const slug of slugList) {
+    const resp = await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`, { headers: cHeaders });
+    if (!resp.ok) continue;
+    const body: any = await resp.json();
+    const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
+    const matchData = allMatches.find(m =>
+      (m.player1_id === t1cid && m.player2_id === t2cid) ||
+      (m.player2_id === t1cid && m.player1_id === t2cid)
+    );
+    if (!matchData) continue;
 
-  await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}/change_state.json`, {
-    method: "PUT",
-    headers: cHeaders,
-    body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
-  });
+    await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}/change_state.json`, {
+      method: "PUT",
+      headers: cHeaders,
+      body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
+    });
+    break;
+  }
 }
 
 export default router;

--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -1764,9 +1764,9 @@ async function update_challonge_match(match_id: string | null, season_id: number
         "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ? ORDER BY map_number ASC",
         [match_id]
       );
-      const isSwapped = matchData.player1_id !== t1cid;
-      const team1Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team2_score : r.team1_score);
-      const team2Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team1_score : r.team2_score);
+      // v2.1 : le PUT utilise participant_id explicite, pas besoin de swapper selon player1/player2
+      const team1Scores: number[] = mapStatsRows.map(r => r.team1_score);
+      const team2Scores: number[] = mapStatsRows.map(r => r.team2_score);
 
       // v2.1 — PUT score update
       await fetch(

--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -1806,10 +1806,10 @@ async function update_challonge_match(match_id: string | null, season_id: number
 /** Marks a Challonge match as underway (called when the first map starts). */
 async function mark_challonge_underway(match_id: string, season_id: number, team1_id: number, team2_id: number): Promise<void> {
   const seasonInfo: RowDataPacket[] = await db.query(
-    "SELECT id, challonge_url, is_challonge FROM season WHERE id = ?",
+    "SELECT id, challonge_url FROM season WHERE id = ?",
     [season_id]
   );
-  if (!seasonInfo.length || !seasonInfo[0].is_challonge) return;
+  if (!seasonInfo.length) return;
   if (seasonInfo[0].challonge_url?.startsWith("t:")) return; // toornament
 
   const decryptedKey = getSetting("challonge.apiKey");

--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -17,10 +17,10 @@ import {
   challongeHeaders,
   parseV2Match,
   buildMatchPutBody,
-  buildMatchStateBody,
   buildTournamentStateBody
 } from "../../utility/challongeV2.js";
 import { getSetting } from "../../services/settings.js";
+import { mark_challonge_match_underway } from "../../services/challonge.js";
 
 /** Rate limit includes.
  * @const
@@ -650,7 +650,7 @@ router.post(
       }
       // Mark Challonge match as underway when the first map starts.
       if (mapNumber === 0 && matchValues[0].season_id) {
-        await mark_challonge_underway(matchID, matchValues[0].season_id, matchValues[0].team1_id, matchValues[0].team2_id);
+        await mark_challonge_match_underway(matchID, matchValues[0].season_id);
       }
       GlobalEmitter.emit("mapStatUpdate");
       res.status(200).send({ message: "Success" });
@@ -1800,56 +1800,6 @@ async function update_challonge_match(match_id: string | null, season_id: number
         GlobalEmitter.emit("seasonUpdate");
       }
     }
-  }
-}
-
-/** Marks a Challonge match as underway (called when the first map starts). */
-async function mark_challonge_underway(match_id: string, season_id: number, team1_id: number, team2_id: number): Promise<void> {
-  const seasonInfo: RowDataPacket[] = await db.query(
-    "SELECT id, challonge_url FROM season WHERE id = ?",
-    [season_id]
-  );
-  if (!seasonInfo.length) return;
-  if (seasonInfo[0].challonge_url?.startsWith("t:")) return; // toornament
-
-  const decryptedKey = getSetting("challonge.apiKey");
-  if (!decryptedKey) return;
-
-  const cHeaders = challongeHeaders(decryptedKey);
-
-  // Cherche dans tous les slugs de la saison (brackets multiples inclus)
-  const tournaments: RowDataPacket[] = await db.query(
-    "SELECT challonge_slug FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC",
-    [season_id]
-  );
-  const slugList: string[] = tournaments.length > 0
-    ? tournaments.map(t => t.challonge_slug as string)
-    : (seasonInfo[0].challonge_url ? [seasonInfo[0].challonge_url as string] : []);
-  if (!slugList.length) return;
-
-  const t1Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team1_id]);
-  const t2Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team2_id]);
-  const t1cid: number = t1Row[0]?.challonge_team_id;
-  const t2cid: number = t2Row[0]?.challonge_team_id;
-  if (!t1cid || !t2cid) return;
-
-  for (const slug of slugList) {
-    const resp = await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`, { headers: cHeaders });
-    if (!resp.ok) continue;
-    const body: any = await resp.json();
-    const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
-    const matchData = allMatches.find(m =>
-      (m.player1_id === t1cid && m.player2_id === t2cid) ||
-      (m.player2_id === t1cid && m.player1_id === t2cid)
-    );
-    if (!matchData) continue;
-
-    await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}/change_state.json`, {
-      method: "PUT",
-      headers: cHeaders,
-      body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
-    });
-    break;
   }
 }
 

--- a/src/routes/legacy/api.ts
+++ b/src/routes/legacy/api.ts
@@ -17,6 +17,7 @@ import {
   challongeHeaders,
   parseV2Match,
   buildMatchPutBody,
+  buildMatchStateBody,
   buildTournamentStateBody
 } from "../../utility/challongeV2.js";
 import { getSetting } from "../../services/settings.js";
@@ -647,6 +648,10 @@ router.post(
         insertSql = "INSERT INTO map_stats SET ?";
         await db.query(insertSql, [insertStmt]);
       }
+      // Mark Challonge match as underway when the first map starts.
+      if (mapNumber === 0 && matchValues[0].season_id) {
+        await mark_challonge_underway(matchID, matchValues[0].season_id, matchValues[0].team1_id, matchValues[0].team2_id);
+      }
       GlobalEmitter.emit("mapStatUpdate");
       res.status(200).send({ message: "Success" });
     } catch (err) {
@@ -752,8 +757,8 @@ router.post(
           updateSql =
             "UPDATE map_stats SET ? WHERE match_id = ? AND map_number = ?";
           await db.query(updateSql, [updateStmt, matchID, mapNumber]);
-          if (matchValues[0].max_maps == 1 && matchValues[0].season_id != null) {
-            // Live update the score.
+          if (matchValues[0].season_id != null) {
+            // Live update the score for all BO formats.
             await update_challonge_match(matchID,
               matchValues[0].season_id,
               matchValues[0].team1_id,
@@ -1325,8 +1330,8 @@ router.post(
           false
         );
       }
-      if (matchValues[0].max_maps != 1 && matchValues[0].season_id != null) {
-        // Live update the score.
+      if (matchValues[0].season_id != null) {
+        // Push per-map scores after map end (no winner yet, series may continue).
         await update_challonge_match(matchID,
           matchValues[0].season_id,
           matchValues[0].team1_id,
@@ -1726,8 +1731,6 @@ async function check_api_key(match_api_key: string, given_api_key: string, match
 async function update_challonge_match(match_id: string | null, season_id: number, team1_id: number, team2_id: number, num_maps: number, winner: string | null = null) {
   // Check if a match has a season ID.
   let sql: string = "SELECT id, challonge_url, user_id FROM season WHERE id = ?";
-  let team1Score: number;
-  let team2Score: number;
   const seasonInfo: RowDataPacket[] = await db.query(sql, [season_id]);
   if (seasonInfo[0].challonge_url) {
     sql = "SELECT challonge_team_id FROM team WHERE id = ?";
@@ -1756,19 +1759,14 @@ async function update_challonge_match(match_id: string | null, season_id: number
     );
 
     if (matchData) {
-      if (num_maps == 1) {
-        sql = "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ?";
-      } else {
-        sql = "SELECT team1_score, team2_score FROM `match` WHERE id = ?";
-      }
-      const mapStats: RowDataPacket[] = await db.query(sql, [match_id]);
-      // Admins may just make a match that has teams swapped.
-      team1Score = matchData.player1_id === t1cid
-        ? mapStats[0].team1_score
-        : mapStats[0].team2_score;
-      team2Score = matchData.player2_id === t2cid
-        ? mapStats[0].team2_score
-        : mapStats[0].team1_score;
+      // Per-map scores from map_stats, ordered by map_number
+      const mapStatsRows: RowDataPacket[] = await db.query(
+        "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ? ORDER BY map_number ASC",
+        [match_id]
+      );
+      const isSwapped = matchData.player1_id !== t1cid;
+      const team1Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team2_score : r.team1_score);
+      const team2Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team1_score : r.team2_score);
 
       // v2.1 — PUT score update
       await fetch(
@@ -1776,7 +1774,7 @@ async function update_challonge_match(match_id: string | null, season_id: number
         {
           method: "PUT",
           headers: cHeaders,
-          body: JSON.stringify(buildMatchPutBody(t1cid, t2cid, team1Score, team2Score, winner))
+          body: JSON.stringify(buildMatchPutBody(t1cid, t2cid, team1Scores, team2Scores, winner))
         }
       );
 
@@ -1803,6 +1801,43 @@ async function update_challonge_match(match_id: string | null, season_id: number
       }
     }
   }
+}
+
+/** Marks a Challonge match as underway (called when the first map starts). */
+async function mark_challonge_underway(match_id: string, season_id: number, team1_id: number, team2_id: number): Promise<void> {
+  const seasonInfo: RowDataPacket[] = await db.query(
+    "SELECT id, challonge_url FROM season WHERE id = ?",
+    [season_id]
+  );
+  if (!seasonInfo.length || !seasonInfo[0].challonge_url) return;
+  if (seasonInfo[0].challonge_url.startsWith("t:")) return; // toornament
+
+  const decryptedKey = getSetting("challonge.apiKey");
+  if (!decryptedKey) return;
+
+  const cHeaders = challongeHeaders(decryptedKey);
+  const slug: string = seasonInfo[0].challonge_url;
+
+  const t1Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team1_id]);
+  const t2Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team2_id]);
+  const t1cid: number = t1Row[0]?.challonge_team_id;
+  const t2cid: number = t2Row[0]?.challonge_team_id;
+  if (!t1cid || !t2cid) return;
+
+  const resp = await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`, { headers: cHeaders });
+  const body: any = await resp.json();
+  const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
+  const matchData = allMatches.find(m =>
+    (m.player1_id === t1cid && m.player2_id === t2cid) ||
+    (m.player2_id === t1cid && m.player1_id === t2cid)
+  );
+  if (!matchData) return;
+
+  await fetch(`${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}/change_state.json`, {
+    method: "PUT",
+    headers: cHeaders,
+    body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
+  });
 }
 
 export default router;

--- a/src/routes/matches/matches.ts
+++ b/src/routes/matches/matches.ts
@@ -1216,7 +1216,9 @@ router.post("/", Utils.ensureAuthenticated, async (req, res, next) => {
           ? req.body[0].min_spectators_to_ready
           : 0,
       map_sides: req.body[0].map_sides !== null ? req.body[0].map_sides : null,
-      wingman: req.body[0]?.wingman 
+      wingman: req.body[0]?.wingman,
+      toornament_id: req.body[0].toornament_id ?? null,
+      challonge_id: req.body[0].challonge_id ?? null,
     };
     let sql: string = "INSERT INTO `match` SET ?";
     let cvarSql: string =

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -28,9 +28,7 @@ import {
   CHALLONGE_V2_BASE,
   challongeHeaders,
   parseV2Match,
-  parseV2Participant,
-  buildMatchPutBody,
-  buildTournamentStateBody
+  parseV2Participant
 } from "../utility/challongeV2.js";
 
 /**

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -1488,6 +1488,7 @@ async function enrichChallongeMatches(
       suggested_play_order: m.suggested_play_order,
       scheduled_time: m.scheduled_time,
       scores_csv: m.scores_csv,
+      score_in_sets: m.score_in_sets,
       player1: p1 ? { id: p1.id, name: p1.display_name, local_team: local1 } : null,
       player2: p2 ? { id: p2.id, name: p2.display_name, local_team: local2 } : null,
       g5_match_id

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -730,10 +730,10 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
           const partBody: any = await partResp.json();
           const participants: any[] = Array.isArray(partBody?.data) ? partBody.data : [];
           if (participants.length > 0) {
-            sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id) VALUES ?";
+            sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id, public_team) VALUES ?";
             const teamArray: Array<Array<any>> = participants.map((item: any) => {
               const p = parseV2Participant(item);
-              return [req.user!.id, p.name.substring(0, 40), p.name.substring(0, 40), p.id];
+              return [req.user!.id, p.name.substring(0, 40), p.name.substring(0, 40), p.id, 1];
             });
             await db.query(sqlString, [teamArray]);
           }
@@ -1449,8 +1449,20 @@ async function enrichChallongeMatches(
 
   return rawMatches.map((item: any) => {
     const m = parseV2Match(item);
-    const p1 = m.player1_id !== null ? (partMap.get(m.player1_id) ?? null) : null;
-    const p2 = m.player2_id !== null ? (partMap.get(m.player2_id) ?? null) : null;
+
+    // Résolution participant : cherche d'abord dans la map principale.
+    // Pour les matchs de phase de groupes, l'ID Challonge peut être différent de
+    // l'ID participant principal → fallback avec un objet minimal pour que le match reste visible.
+    const resolveParticipant = (pid: number | null) => {
+      if (pid === null) return null;
+      const found = partMap.get(pid);
+      if (found) return found;
+      // Participant non trouvé (phase de groupes avec IDs internes) : retourne un placeholder
+      return { id: pid, display_name: `#${pid}`, name: `#${pid}` };
+    };
+
+    const p1 = resolveParticipant(m.player1_id);
+    const p2 = resolveParticipant(m.player2_id);
     const local1 = p1 ? (teamByChallongeId.get(String(p1.id)) ?? null) : null;
     const local2 = p2 ? (teamByChallongeId.get(String(p2.id)) ?? null) : null;
     const t1id = (local1 as any)?.id;

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -1438,11 +1438,20 @@ async function enrichChallongeMatches(
   );
 
   const challongeIds = rawParts.map((item: any) => parseInt(item.id, 10));
+
+  // Inclure aussi les IDs de participants qui apparaissent directement dans les matchs
+  // (les endpoints participants et matches peuvent retourner des ensembles d'IDs différents)
+  const matchPlayerIds = rawMatches.flatMap((item: any) => {
+    const m = parseV2Match(item);
+    return [m.player1_id, m.player2_id].filter((id): id is number => id !== null);
+  });
+  const allLookupIds = [...new Set([...challongeIds, ...matchPlayerIds])];
+
   let localTeams: RowDataPacket[] = [];
-  if (challongeIds.length > 0) {
+  if (allLookupIds.length > 0) {
     localTeams = await db.query(
-      `SELECT id, name, challonge_team_id FROM team WHERE challonge_team_id IN (${challongeIds.map(() => "?").join(",")})`,
-      challongeIds.map(String)
+      `SELECT id, name, challonge_team_id FROM team WHERE challonge_team_id IN (${allLookupIds.map(() => "?").join(",")})`,
+      allLookupIds.map(String)
     );
   }
   const teamByChallongeId = new Map(localTeams.map(t => [String(t.challonge_team_id), t]));

--- a/src/routes/seasons.ts
+++ b/src/routes/seasons.ts
@@ -24,6 +24,14 @@ import { ToornamentTokenResponse } from "../types/toornament/ToornamentTokenResp
 import { ToornamentMatch } from "../types/toornament/ToornamentMatch.js";
 
 import { getSetting } from "../services/settings.js";
+import {
+  CHALLONGE_V2_BASE,
+  challongeHeaders,
+  parseV2Match,
+  parseV2Participant,
+  buildMatchPutBody,
+  buildTournamentStateBody
+} from "../utility/challongeV2.js";
 
 /**
  * @swagger
@@ -675,59 +683,67 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res, next) => {
     }
 
 
-    const userInfo: RowDataPacket[] = await db.query("SELECT challonge_api_key FROM user WHERE id = ?", [req.user!.id]);
-    let challongeAPIKey: string | undefined | null = Utils.decrypt(userInfo[0].challonge_api_key);
-    if (!challongeAPIKey) {
-      throw "No challonge API key provided for user.";
-    }
+    const challongeAPIKey = getChallongeAPIKey();
 
     let tournamentId: string = req.body[0].tournament_id;
     if (!/^[\w\-]+$/.test(tournamentId)) {
       throw new Error("Invalid tournament ID.");
     }
-    let challongeResponse: any = await fetch(
-      "https://api.challonge.com/v1/tournaments/" +
-      tournamentId +
-      ".json?api_key=" +
-      challongeAPIKey +
-      "&include_participants=1");
-
-    let challongeData = await challongeResponse.json();
-    if (challongeData) {
+    // v2.1 — GET tournament info
+    const cHeaders = challongeHeaders(challongeAPIKey);
+    const tournResp: any = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${tournamentId}.json`,
+      { headers: cHeaders }
+    );
+    if (!tournResp.ok) throw new Error(`Challonge API error: ${tournResp.status}`);
+    const tournBody: any = await tournResp.json();
+    const tournAttrs = tournBody?.data?.attributes;
+    if (tournAttrs) {
       // Insert the season.
       let sqlString: string = "INSERT INTO season SET ?";
       let seasonData: SeasonObject = {
         user_id: req.user?.id,
-        name: challongeData.tournament.name,
-        start_date: new Date(challongeData.tournament.created_at),
+        name: tournAttrs.name,
+        start_date: tournAttrs.starts_at ? new Date(tournAttrs.starts_at) : new Date(),
         is_challonge: true,
-        challonge_svg: challongeData.tournament.live_image_url,
+        challonge_svg: null, // not exposed in v2.1
         challonge_url: tournamentId
       };
       const insertSeason: RowDataPacket[] = await db.query(sqlString, seasonData);
-      // Check if teams were already in the call and add them to the database.
-      if (req.body[0]?.import_teams && challongeData.tournament.participants) {
-        sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id) VALUES ?";
-        let teamArray: Array<Array<Object>> = [];
-        challongeData.tournament.participants.forEach(async (team: { participant: { display_name: string; id: Object; }; }) => {
-          teamArray.push([
-            req.user!.id,
-            team.participant.display_name.substring(0, 40),
-            team.participant.display_name.substring(0, 40),
-            team.participant.id
-          ]);
-        });
-        await db.query(sqlString, [teamArray]);
+      //@ts-ignore
+      const newSeasonId: number = insertSeason.insertId;
+
+      // Enregistrer le tournoi dans season_challonge_tournament
+      const label: string = req.body[0]?.label || "Main";
+      await db.query(
+        "INSERT INTO season_challonge_tournament (season_id, challonge_slug, label, display_order) VALUES (?, ?, ?, 0)",
+        [newSeasonId, tournamentId, label]
+      );
+
+      // v2.1 — import teams via separate participants call
+      if (req.body[0]?.import_teams) {
+        const partResp: any = await fetch(
+          `${CHALLONGE_V2_BASE}/tournaments/${tournamentId}/participants.json?per_page=500`,
+          { headers: cHeaders }
+        );
+        if (partResp.ok) {
+          const partBody: any = await partResp.json();
+          const participants: any[] = Array.isArray(partBody?.data) ? partBody.data : [];
+          if (participants.length > 0) {
+            sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id) VALUES ?";
+            const teamArray: Array<Array<any>> = participants.map((item: any) => {
+              const p = parseV2Participant(item);
+              return [req.user!.id, p.name.substring(0, 40), p.name.substring(0, 40), p.id];
+            });
+            await db.query(sqlString, [teamArray]);
+          }
+        }
       }
 
-
-
-      
       res.json({
         message: "Challonge season imported successfully!",
-        chal_res: challongeData.tournament.created_at,
-        //@ts-ignore
-        id: insertSeason.insertId,
+        chal_res: tournAttrs.starts_at ?? null,
+        id: newSeasonId,
       });
     }
 
@@ -943,13 +959,17 @@ router.get("/:season_id/toornament/matches", Utils.ensureAuthenticated, async (r
     }
     const teamByChallongeId = new Map(localTeams.map(t => [String(t.challonge_team_id), t]));
 
-    // Find existing G5 matches for this season (cross-reference by team pair)
+    // Find existing G5 matches for this season by toornament_id (precise) or team pair (fallback)
     const g5Matches: RowDataPacket[] = await db.query(
-      "SELECT id, team1_id, team2_id FROM `match` WHERE season_id = ?",
+      "SELECT id, team1_id, team2_id, toornament_id FROM `match` WHERE season_id = ?",
       [seasonId]
     );
+    const g5ByToornamentId = new Map<string, number>();
     const g5MatchMap = new Map<string, number>();
     for (const m of g5Matches) {
+      if (m.toornament_id) {
+        g5ByToornamentId.set(String(m.toornament_id), m.id);
+      }
       const key1 = `${m.team1_id}:${m.team2_id}`;
       const key2 = `${m.team2_id}:${m.team1_id}`;
       if (!g5MatchMap.has(key1) || g5MatchMap.get(key1)! < m.id) g5MatchMap.set(key1, m.id);
@@ -963,7 +983,10 @@ router.get("/:season_id/toornament/matches", Utils.ensureAuthenticated, async (r
       }));
       const t1 = (enrichedOpponents[0]?.local_team as any)?.id;
       const t2 = (enrichedOpponents[1]?.local_team as any)?.id;
-      const g5_match_id = (t1 && t2) ? (g5MatchMap.get(`${t1}:${t2}`) ?? null) : null;
+      // Prefer match by toornament_id (unique), fallback to team pair for old records
+      const g5_match_id =
+        g5ByToornamentId.get(String(match.id)) ??
+        ((t1 && t2) ? (g5MatchMap.get(`${t1}:${t2}`) ?? null) : null);
       return { ...match, opponents: enrichedOpponents, g5_match_id };
     });
 
@@ -1331,6 +1354,339 @@ router.delete("/:season_id/teams/:team_id", Utils.ensureAuthenticated, async (re
     const teamId = parseInt(req.params.team_id);
     await db.query("DELETE FROM teams_seasons WHERE season_id = ? AND teams_id = ?", [seasonId, teamId]);
     res.json({ message: "Team removed from season successfully!" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+// ─── Challonge match import ──────────────────────────────────────────────────
+
+function getChallongeAPIKey(): string {
+  const key = getSetting("challonge.apiKey");
+  if (!key) throw new Error("Clé API Challonge non configurée dans les paramètres administrateur.");
+  return key;
+}
+
+/** Retourne tous les brackets Challonge d'une saison (depuis season_challonge_tournament) */
+async function getSeasonChallongeTournaments(seasonId: number): Promise<RowDataPacket[]> {
+  const rows: RowDataPacket[] = await db.query(
+    "SELECT id, challonge_slug, label, display_order FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC, id ASC",
+    [seasonId]
+  );
+  if (!rows.length) throw new Error("Aucun tournoi Challonge trouvé pour cette saison.");
+  return rows;
+}
+
+/** Trouve le slug Challonge qui contient le match donné (via challonge_id sur la table match) */
+async function getSlugForMatch(seasonId: number, challongeMatchId: number, apiKey: string): Promise<string> {
+  // Cherche d'abord via le match G5 existant (challonge_id stocké)
+  const existing: RowDataPacket[] = await db.query(
+    "SELECT sct.challonge_slug FROM `match` m " +
+    "JOIN season_challonge_tournament sct ON sct.season_id = m.season_id " +
+    "WHERE m.challonge_id = ? AND m.season_id = ? LIMIT 1",
+    [challongeMatchId, seasonId]
+  );
+  if (existing.length) return existing[0].challonge_slug as string;
+
+  // Sinon cherche en interrogeant chaque tournoi Challonge (v2.1)
+  const tournaments = await getSeasonChallongeTournaments(seasonId);
+  const cHeaders = challongeHeaders(apiKey);
+  for (const t of tournaments) {
+    const resp = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${t.challonge_slug}/matches/${challongeMatchId}.json`,
+      { headers: cHeaders }
+    );
+    if (resp.ok) return t.challonge_slug as string;
+  }
+  throw new Error(`Match Challonge ${challongeMatchId} introuvable dans les tournois de la saison.`);
+}
+
+/** Helper partagé : enrichit les matchs d'un slug avec local_team + g5_match_id (v2.1) */
+async function enrichChallongeMatches(
+  slug: string,
+  label: string,
+  apiKey: string,
+  state: string | undefined,
+  g5ByChallongeId: Map<number, number>,
+  g5ByTeamPair: Map<string, number>
+): Promise<any[]> {
+  const cHeaders = challongeHeaders(apiKey);
+
+  // v2.1 — liste des matchs
+  let url = `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?per_page=500`;
+  if (state) url += `&state=${state}`;
+  const resp = await fetch(url, { headers: cHeaders });
+  if (!resp.ok) return [];
+  const rawBody: any = await resp.json();
+  // v2.1: { data: [ { id, attributes: { state, round, ..., relationships: { player1, player2 } } } ] }
+  const rawMatches: any[] = Array.isArray(rawBody?.data) ? rawBody.data : [];
+
+  // v2.1 — liste des participants
+  const partResp = await fetch(
+    `${CHALLONGE_V2_BASE}/tournaments/${slug}/participants.json?per_page=500`,
+    { headers: cHeaders }
+  );
+  const partBody: any = partResp.ok ? await partResp.json() : {};
+  const rawParts: any[] = Array.isArray(partBody?.data) ? partBody.data : [];
+  // Map: challongeId (number) → participant { id, display_name, name }
+  const partMap = new Map<number, any>(
+    rawParts.map((item: any) => {
+      const p = parseV2Participant(item);
+      return [p.id, p];
+    })
+  );
+
+  const challongeIds = rawParts.map((item: any) => parseInt(item.id, 10));
+  let localTeams: RowDataPacket[] = [];
+  if (challongeIds.length > 0) {
+    localTeams = await db.query(
+      `SELECT id, name, challonge_team_id FROM team WHERE challonge_team_id IN (${challongeIds.map(() => "?").join(",")})`,
+      challongeIds.map(String)
+    );
+  }
+  const teamByChallongeId = new Map(localTeams.map(t => [String(t.challonge_team_id), t]));
+
+  return rawMatches.map((item: any) => {
+    const m = parseV2Match(item);
+    const p1 = m.player1_id !== null ? (partMap.get(m.player1_id) ?? null) : null;
+    const p2 = m.player2_id !== null ? (partMap.get(m.player2_id) ?? null) : null;
+    const local1 = p1 ? (teamByChallongeId.get(String(p1.id)) ?? null) : null;
+    const local2 = p2 ? (teamByChallongeId.get(String(p2.id)) ?? null) : null;
+    const t1id = (local1 as any)?.id;
+    const t2id = (local2 as any)?.id;
+    const g5_match_id =
+      g5ByChallongeId.get(m.id) ??
+      ((t1id && t2id) ? (g5ByTeamPair.get(`${t1id}:${t2id}`) ?? null) : null);
+    return {
+      id: m.id,
+      slug,
+      tournament_label: label,
+      state: m.state,
+      round: m.round,
+      suggested_play_order: m.suggested_play_order,
+      scheduled_time: m.scheduled_time,
+      scores_csv: m.scores_csv,
+      player1: p1 ? { id: p1.id, name: p1.display_name, local_team: local1 } : null,
+      player2: p2 ? { id: p2.id, name: p2.display_name, local_team: local2 } : null,
+      g5_match_id
+    };
+  });
+}
+
+/** GET /:season_id/challonge/tournaments — liste les brackets de la saison */
+router.get("/:season_id/challonge/tournaments", Utils.ensureAuthenticated, async (req, res) => {
+  try {
+    const seasonId = parseInt(req.params.season_id);
+    const tournaments = await getSeasonChallongeTournaments(seasonId);
+    res.json({ tournaments });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+/** POST /:season_id/challonge/tournaments — ajouter un bracket supplémentaire */
+router.post("/:season_id/challonge/tournaments", Utils.ensureAuthenticated, async (req, res) => {
+  try {
+    const seasonId = parseInt(req.params.season_id);
+    const { challonge_slug, label } = req.body;
+    if (!challonge_slug || !/^[\w\-]+$/.test(challonge_slug)) {
+      res.status(400).json({ message: "Slug Challonge invalide." });
+      return;
+    }
+    // Vérifier que la saison appartient à l'utilisateur ou est admin
+    const seasonRows: RowDataPacket[] = await db.query(
+      "SELECT user_id FROM season WHERE id = ? AND is_challonge = 1",
+      [seasonId]
+    );
+    if (!seasonRows.length) {
+      res.status(404).json({ message: "Saison introuvable ou pas une saison Challonge." });
+      return;
+    }
+    if (seasonRows[0].user_id !== req.user!.id && !Utils.superAdminCheck(req.user!)) {
+      res.status(403).json({ message: "Non autorisé." });
+      return;
+    }
+    // Vérifier que le tournoi Challonge est accessible (v2.1)
+    const apiKey = getChallongeAPIKey();
+    const checkResp = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${challonge_slug}.json`,
+      { headers: challongeHeaders(apiKey) }
+    );
+    if (!checkResp.ok) {
+      res.status(400).json({ message: "Tournoi Challonge introuvable ou inaccessible." });
+      return;
+    }
+    const checkBody: any = await checkResp.json();
+    const tData = checkBody?.data?.attributes ?? {};
+    const existingTournaments: RowDataPacket[] = await db.query(
+      "SELECT COUNT(*) as cnt FROM season_challonge_tournament WHERE season_id = ?",
+      [seasonId]
+    );
+    const displayOrder: number = existingTournaments[0]?.cnt ?? 0;
+    await db.query(
+      "INSERT INTO season_challonge_tournament (season_id, challonge_slug, label, display_order) VALUES (?, ?, ?, ?)",
+      [seasonId, challonge_slug, label || tData.name || challonge_slug, displayOrder]
+      // tData.name comes from v2.1 attributes object
+    );
+    res.json({ message: "Bracket ajouté avec succès.", name: tData.name });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+/** DELETE /:season_id/challonge/tournaments/:tournament_id — supprimer un bracket */
+router.delete("/:season_id/challonge/tournaments/:tournament_id", Utils.ensureAuthenticated, async (req, res) => {
+  try {
+    const seasonId = parseInt(req.params.season_id);
+    const tournamentId = parseInt(req.params.tournament_id);
+    const seasonRows: RowDataPacket[] = await db.query(
+      "SELECT user_id FROM season WHERE id = ?",
+      [seasonId]
+    );
+    if (!seasonRows.length) { res.status(404).json({ message: "Saison introuvable." }); return; }
+    if (seasonRows[0].user_id !== req.user!.id && !Utils.superAdminCheck(req.user!)) {
+      res.status(403).json({ message: "Non autorisé." }); return;
+    }
+    await db.query(
+      "DELETE FROM season_challonge_tournament WHERE id = ? AND season_id = ?",
+      [tournamentId, seasonId]
+    );
+    res.json({ message: "Bracket supprimé." });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+/** GET /:season_id/challonge/matches — tous les matchs de tous les brackets, enrichis */
+router.get("/:season_id/challonge/matches", Utils.ensureAuthenticated, async (req, res) => {
+  try {
+    const seasonId = parseInt(req.params.season_id);
+    const apiKey = getChallongeAPIKey();
+    const tournaments = await getSeasonChallongeTournaments(seasonId);
+    const { state, tournament_id } = req.query;
+
+    // G5 match index (partagé entre tous les tournois)
+    const g5Matches: RowDataPacket[] = await db.query(
+      "SELECT id, team1_id, team2_id, challonge_id FROM `match` WHERE season_id = ?",
+      [seasonId]
+    );
+    const g5ByChallongeId = new Map<number, number>();
+    const g5ByTeamPair = new Map<string, number>();
+    for (const m of g5Matches) {
+      if (m.challonge_id) g5ByChallongeId.set(Number(m.challonge_id), m.id);
+      const k1 = `${m.team1_id}:${m.team2_id}`;
+      const k2 = `${m.team2_id}:${m.team1_id}`;
+      if (!g5ByTeamPair.has(k1) || g5ByTeamPair.get(k1)! < m.id) g5ByTeamPair.set(k1, m.id);
+      if (!g5ByTeamPair.has(k2) || g5ByTeamPair.get(k2)! < m.id) g5ByTeamPair.set(k2, m.id);
+    }
+
+    // Filtrer par tournament_id si précisé
+    const filtered = tournament_id
+      ? tournaments.filter(t => t.id === parseInt(tournament_id as string))
+      : tournaments;
+
+    const results = await Promise.all(
+      filtered.map(t =>
+        enrichChallongeMatches(
+          t.challonge_slug as string,
+          t.label as string,
+          apiKey,
+          state as string | undefined,
+          g5ByChallongeId,
+          g5ByTeamPair
+        )
+      )
+    );
+
+    res.json({ tournaments, matches: results.flat() });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+/** GET /:season_id/challonge/matches/:challonge_match_id/prefill */
+router.get("/:season_id/challonge/matches/:challonge_match_id/prefill", Utils.ensureAuthenticated, async (req, res) => {
+  try {
+    const seasonId = parseInt(req.params.season_id);
+    const challongeMatchId = parseInt(req.params.challonge_match_id);
+    if (isNaN(challongeMatchId)) throw new Error("ID de match Challonge invalide.");
+
+    const apiKey = getChallongeAPIKey();
+    const slug = await getSlugForMatch(seasonId, challongeMatchId, apiKey);
+
+    // v2.1 — récupérer le match
+    const cHeaders = challongeHeaders(apiKey);
+    const mResp = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}.json`,
+      { headers: cHeaders }
+    );
+    if (!mResp.ok) throw new Error(`Challonge API error: ${mResp.status}`);
+    const mBody: any = await mResp.json();
+    // v2.1: { data: { id, attributes: { state, round, ..., relationships: { player1, player2 } } } }
+    const m = parseV2Match(mBody.data);
+
+    const resolveParticipant = async (playerId: number | null) => {
+      if (!playerId) return null;
+      // v2.1 — récupérer le participant
+      const pResp = await fetch(
+        `${CHALLONGE_V2_BASE}/tournaments/${slug}/participants/${playerId}.json`,
+        { headers: cHeaders }
+      );
+      if (!pResp.ok) return null;
+      const pBody: any = await pResp.json();
+      // v2.1: { data: { id, attributes: { name } } }
+      const p = parseV2Participant(pBody.data);
+      const rows: RowDataPacket[] = await db.query(
+        "SELECT id, name FROM team WHERE challonge_team_id = ?",
+        [String(p.id)]
+      );
+      return { id: p.id, name: p.display_name, local_team: rows[0] ?? null };
+    };
+
+    const [player1, player2] = await Promise.all([
+      resolveParticipant(m.player1_id),
+      resolveParticipant(m.player2_id)
+    ]);
+
+    const seasonRows: RowDataPacket[] = await db.query(
+      "SELECT s.id, s.name, CONCAT('{', GROUP_CONCAT(DISTINCT CONCAT('\"',sc.cvar_name,'\": \"',sc.cvar_value,'\"')),'}') as cvars " +
+      "FROM season s LEFT OUTER JOIN season_cvar sc ON s.id = sc.season_id WHERE s.id = ? GROUP BY s.id",
+      [seasonId]
+    );
+    const season = seasonRows[0];
+    if (season?.cvars) season.cvars = JSON.parse(season.cvars);
+
+    const availableServers: RowDataPacket[] = await db.query(
+      "SELECT gs.id, gs.display_name, gs.ip_string, gs.port, gs.public_server, gs.flag " +
+      "FROM game_server gs WHERE gs.in_use = 0 AND (gs.public_server = 1 OR gs.user_id = ?) ORDER BY gs.display_name",
+      [req.user!.id]
+    );
+
+    res.json({
+      season_id: seasonId,
+      season_name: season?.name ?? null,
+      season_cvars: season?.cvars ?? null,
+      team1: player1?.local_team ?? null,
+      team2: player2?.local_team ?? null,
+      max_maps: 1,
+      challonge_match_id: challongeMatchId,
+      challonge_match: {
+        id: m.id,
+        slug,
+        state: m.state,
+        round: m.round,
+        suggested_play_order: m.suggested_play_order,
+        scheduled_time: m.scheduled_time, // mapped from v2.1 attributes
+        player1,
+        player2
+      },
+      available_servers: availableServers
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: (err as Error).toString() });

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -90,6 +90,7 @@ router.put("/", Utils.ensureAuthenticated, requireSuperAdmin, async (req: Reques
       "twitch.enabled", "twitch.username", "twitch.token", "twitch.channels",
       "pterodactyl.enabled", "pterodactyl.url", "pterodactyl.apiKey", "pterodactyl.shutdownDelay",
       "toornament.clientId", "toornament.clientSecret", "toornament.apiKey",
+      "challonge.apiKey",
       "teamspeak.enabled", "teamspeak.host", "teamspeak.queryPort", "teamspeak.username",
       "teamspeak.password", "teamspeak.serverId",
     ]);

--- a/src/routes/teams.ts
+++ b/src/routes/teams.ts
@@ -956,29 +956,35 @@ router.get("/:team_id/result/:match_id", async (req, res) => {
 router.post("/challonge", Utils.ensureAuthenticated, async (req, res) => {
 
   try {
-    let userID: number = req.user!.id;
-    const userInfo: RowDataPacket[] = await db.query("SELECT challonge_api_key FROM user WHERE id = ?", [userID]);
-    let challongeAPIKey: string | undefined | null = Utils.decrypt(userInfo[0].challonge_api_key);
     let tournamentId: string = req.body[0].tournament_id;
     if (!/^[\w\-]+$/.test(tournamentId)) {
       throw new Error("Invalid tournament ID.");
     }
-    let challongeResponse: any = await fetch("https://api.challonge.com/v1/tournaments/" + tournamentId + "/participants.json?api_key=" + challongeAPIKey);
-    let challongeData: any = await challongeResponse.json();
-    if (!challongeData) {
+    // v2.1 — récupération des participants via clé système
+    const { CHALLONGE_V2_BASE, challongeHeaders, parseV2Participant } = await import("../utility/challongeV2.js");
+    const { getSetting } = await import("../services/settings.js");
+    const challongeAPIKey = getSetting("challonge.apiKey");
+    if (!challongeAPIKey) {
+      throw new Error("Clé API Challonge non configurée dans les paramètres administrateur.");
+    }
+    const challongeResponse: any = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${tournamentId}/participants.json?per_page=500`,
+      { headers: challongeHeaders(challongeAPIKey) }
+    );
+    const challongeBody: any = await challongeResponse.json();
+    const participants: any[] = Array.isArray(challongeBody?.data) ? challongeBody.data : [];
+    if (!participants.length) {
       throw new Error("No teams found for the provided tournament.");
     }
     let sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id) VALUES ?";
-    if (!challongeAPIKey) {
-      throw "No challonge API key provided for user.";
-    }
     let teamArray: Array<any> = [];
-    challongeData.forEach(async (team: { participant: { display_name: string; id: any; }; }) => {
+    participants.forEach((item: any) => {
+      const p = parseV2Participant(item);
       teamArray.push([
         req.user?.id,
-        team.participant.display_name.substring(0, 40),
-        team.participant.display_name.substring(0, 40),
-        team.participant.id
+        p.name.substring(0, 40),
+        p.name.substring(0, 40),
+        p.id
       ]);
     });
     await db.query(sqlString, [teamArray]);

--- a/src/routes/teams.ts
+++ b/src/routes/teams.ts
@@ -976,7 +976,7 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res) => {
     if (!participants.length) {
       throw new Error("No teams found for the provided tournament.");
     }
-    let sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id) VALUES ?";
+    let sqlString = "INSERT INTO team (user_id, name, tag, challonge_team_id, public_team) VALUES ?";
     let teamArray: Array<any> = [];
     participants.forEach((item: any) => {
       const p = parseV2Participant(item);
@@ -984,7 +984,8 @@ router.post("/challonge", Utils.ensureAuthenticated, async (req, res) => {
         req.user?.id,
         p.name.substring(0, 40),
         p.name.substring(0, 40),
-        p.id
+        p.id,
+        1
       ]);
     });
     await db.query(sqlString, [teamArray]);

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -134,10 +134,9 @@ async function update_challonge_match(
       [match_id]
     );
 
-    // Ajuster selon la position player1/player2 dans Challonge
-    const isSwapped = matchData.player1_id !== t1cid;
-    const team1Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team2_score : r.team1_score);
-    const team2Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team1_score : r.team2_score);
+    // v2.1 : le PUT utilise participant_id explicite, pas besoin de swapper selon player1/player2
+    const team1Scores: number[] = mapStatsRows.map(r => r.team1_score);
+    const team2Scores: number[] = mapStatsRows.map(r => r.team2_score);
 
     // PUT v2.1 — mise à jour du score
     await fetch(

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -128,17 +128,16 @@ async function update_challonge_match(
 
     if (!matchData) continue;
 
-    // Récupérer les scores
-    const scoreSql = num_maps === 1
-      ? "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ?"
-      : "SELECT team1_score, team2_score FROM `match` WHERE id = ?";
-    const mapStats: RowDataPacket[] = await db.query(scoreSql, [match_id]);
+    // Récupérer tous les scores par map (live + terminés), triés par map_number
+    const mapStatsRows: RowDataPacket[] = await db.query(
+      "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ? ORDER BY map_number ASC",
+      [match_id]
+    );
 
-    // Ajuster les scores selon la position player1/player2 dans Challonge
-    const team1Score: number = matchData.player1_id === t1cid
-      ? mapStats[0].team1_score : mapStats[0].team2_score;
-    const team2Score: number = matchData.player2_id === t2cid
-      ? mapStats[0].team2_score : mapStats[0].team1_score;
+    // Ajuster selon la position player1/player2 dans Challonge
+    const isSwapped = matchData.player1_id !== t1cid;
+    const team1Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team2_score : r.team1_score);
+    const team2Scores: number[] = mapStatsRows.map(r => isSwapped ? r.team1_score : r.team2_score);
 
     // PUT v2.1 — mise à jour du score
     await fetch(
@@ -146,7 +145,7 @@ async function update_challonge_match(
       {
         method: "PUT",
         headers,
-        body: JSON.stringify(buildMatchPutBody(t1cid, t2cid, team1Score, team2Score, winner))
+        body: JSON.stringify(buildMatchPutBody(t1cid, t2cid, team1Scores, team2Scores, winner))
       }
     );
 

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -228,9 +228,7 @@ export async function mark_challonge_match_underway(
   console.log(`[Challonge] mark_underway: slugList=${JSON.stringify(slugList)}`);
   if (!slugList.length) { console.log("[Challonge] mark_underway: no slugs, abort"); return; }
 
-  const baseHeaders = challongeHeaders(decryptedKey);
-  // change_state.json attend application/json, pas application/vnd.api+json
-  const headers = { ...baseHeaders, "Content-Type": "application/json" };
+  const headers = challongeHeaders(decryptedKey);
 
   for (const slug of slugList) {
     const url = `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}/change_state.json`;

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -228,7 +228,9 @@ export async function mark_challonge_match_underway(
   console.log(`[Challonge] mark_underway: slugList=${JSON.stringify(slugList)}`);
   if (!slugList.length) { console.log("[Challonge] mark_underway: no slugs, abort"); return; }
 
-  const headers = challongeHeaders(decryptedKey);
+  const baseHeaders = challongeHeaders(decryptedKey);
+  // change_state.json attend application/json, pas application/vnd.api+json
+  const headers = { ...baseHeaders, "Content-Type": "application/json" };
 
   for (const slug of slugList) {
     const url = `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}/change_state.json`;

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -1,9 +1,17 @@
-/** Fetch for Challonge API integration.
+/** Fetch for Challonge API v2.1 integration.
  * @const
  */
 import fetch from "node-fetch";
 
-import Utils from "../utility/utils.js";
+import {
+  CHALLONGE_V2_BASE,
+  challongeHeaders,
+  parseV2Match,
+  buildMatchPutBody,
+  buildTournamentStateBody
+} from "../utility/challongeV2.js";
+
+import { getSetting } from "./settings.js";
 
 import update_toornament_match from "./toornament.js";
 
@@ -12,15 +20,14 @@ import update_toornament_match from "./toornament.js";
  */
 import {db} from "../services/db.js";
 
-
-/** 
+/**
  * @const
  * Global Server Sent Emitter class for real time data.
  */
 import GlobalEmitter from "../utility/emitter.js";
 import { RowDataPacket } from "mysql2";
 
-/*** A PUT call to Challonge to update a match that is currently being played.
+/*** A PUT call to Challonge v2.1 to update a match that is currently being played.
  * @function
  * @memberof module:legacy/api
  * @param {number} match_id - The internal ID of the match being played.
@@ -30,7 +37,7 @@ import { RowDataPacket } from "mysql2";
  * @param {number} num_maps - The number of maps in the current match.
  * @param {string} [winner=null] - The string value representing the winner of the match.
  */
-export default 
+export default
 async function update_challonge_match(
   match_id: number | string,
   season_id: number,
@@ -39,135 +46,148 @@ async function update_challonge_match(
   num_maps: number,
   winner: string | null = null
 ): Promise<void> {
-  // Check if a match has a season ID.
-  let sql: string =
-    "SELECT id, challonge_url, user_id FROM season WHERE id = ?";
-  let team1Score: number;
-  let team2Score: number;
-  const seasonInfo: RowDataPacket[] = await db.query(sql, [season_id]);
-  if (seasonInfo[0].challonge_url) {
-    if (seasonInfo[0].challonge_url.startsWith("t:")) {
-      update_toornament_match(seasonInfo[0].challonge_url.slice(2), match_id, team1_id, team2_id, num_maps, winner);
+  // Récupérer la saison
+  const seasonInfo: RowDataPacket[] = await db.query(
+    "SELECT id, challonge_url, user_id, is_challonge FROM season WHERE id = ?",
+    [season_id]
+  );
+  if (!seasonInfo.length || !seasonInfo[0].is_challonge) return;
+
+  // Toornament : déléguer
+  if (seasonInfo[0].challonge_url?.startsWith("t:")) {
+    update_toornament_match(seasonInfo[0].challonge_url.slice(2), match_id, team1_id, team2_id, num_maps, winner);
+    return;
+  }
+
+  // Récupérer la clé API Challonge depuis les paramètres système
+  const decryptedKey = getSetting("challonge.apiKey");
+  if (!decryptedKey) return;
+
+  const headers = challongeHeaders(decryptedKey);
+
+  // Trouver le challonge_id stocké sur le match G5
+  const matchRow: RowDataPacket[] = await db.query(
+    "SELECT challonge_id FROM `match` WHERE id = ?",
+    [match_id]
+  );
+  const challongeMatchId: number | null = matchRow[0]?.challonge_id ?? null;
+
+  // Récupérer tous les brackets de la saison
+  const tournaments: RowDataPacket[] = await db.query(
+    "SELECT challonge_slug FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC",
+    [season_id]
+  );
+
+  // Fallback sur challonge_url si pas de brackets dans la nouvelle table
+  const slugList: string[] = tournaments.length > 0
+    ? tournaments.map(t => t.challonge_slug as string)
+    : (seasonInfo[0].challonge_url ? [seasonInfo[0].challonge_url as string] : []);
+
+  if (!slugList.length) return;
+
+  const team1ChallongeId: RowDataPacket[] = await db.query(
+    "SELECT challonge_team_id FROM team WHERE id = ?",
+    [team1_id]
+  );
+  const team2ChallongeId: RowDataPacket[] = await db.query(
+    "SELECT challonge_team_id FROM team WHERE id = ?",
+    [team2_id]
+  );
+
+  const t1cid: number = team1ChallongeId[0].challonge_team_id;
+  const t2cid: number = team2ChallongeId[0].challonge_team_id;
+
+  for (const slug of slugList) {
+    let matchData: any | null = null;
+
+    if (challongeMatchId) {
+      // Cherche directement par ID de match Challonge (v2.1)
+      const resp = await fetch(
+        `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}.json`,
+        { headers }
+      );
+      if (!resp.ok) continue;
+      const body: any = await resp.json();
+      // v2.1 single match response: { data: { id, attributes: { ... } } }
+      if (body?.data) matchData = parseV2Match(body.data);
     } else {
-      sql = "SELECT challonge_team_id FROM team WHERE id = ?";
-      const team1ChallongeId: RowDataPacket[] = await db.query(sql, [team1_id]);
-      const team2ChallongeId: RowDataPacket[] = await db.query(sql, [team2_id]);
-
-      // Grab API key.
-      sql = "SELECT challonge_api_key FROM user WHERE id = ?";
-      const challongeAPIKey: RowDataPacket[] = await db.query(sql, [seasonInfo[0].user_id]);
-      let decryptedKey: string | null | undefined = Utils.decrypt(
-        challongeAPIKey[0].challonge_api_key
+      // Fallback : récupère tous les matchs ouverts et filtre par participants
+      const resp = await fetch(
+        `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
+        { headers }
       );
-      // Get info of the current open match with the two IDs.
-      let challongeResponse = await fetch(
-        "https://api.challonge.com/v1/tournaments/" +
-          seasonInfo[0].challonge_url +
-          "/matches.json?api_key=" +
-          decryptedKey +
-          "&state=open&participant_id=" +
-          team1ChallongeId[0].challonge_team_id +
-          "&participant_id=" +
-          team2ChallongeId[0].challonge_team_id
-      );
-      let challongeData: any = await challongeResponse.json();
-      if (challongeData) {
-
-        let correctIndex = -1; // Initialize with -1 to indicate not found
-
-        // Iterate through the team1ChallongeId array to find the correct index
-        for (let i = 0; i < challongeData.length; i++) {
-          if ((challongeData[i].match.player1_id === team1ChallongeId[0].challonge_team_id && challongeData[i].match.player2_id === team2ChallongeId[0].challonge_team_id) ||
-              (challongeData[i].match.player2_id === team1ChallongeId[0].challonge_team_id && challongeData[i].match.player1_id === team2ChallongeId[0].challonge_team_id)) {
-            correctIndex = i;
-            break; // Exit the loop once the correct index is found
-          }
-        }
-
-        // If correctIndex remains -1, it means no matching index was found based on the conditions
-        if (correctIndex === -1) {
-          console.log("No matching index found.");
-
-        } else {
-          console.log(`Correct index found: ${correctIndex}`);
-  if (num_maps == 1) {
-            // Submit the map stats scores instead.
-            sql =
-              "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ?";
-          } else {
-            sql = "SELECT team1_score, team2_score FROM `match` WHERE id = ?";
-          }
-          const mapStats: RowDataPacket[] = await db.query(sql, [match_id]);
-          // Admins may just make a match that has teams swapped. This is okay as we can change what we
-          // report to Challonge.
-          team1Score =
-            challongeData[correctIndex].match.player1_id ==
-            team1ChallongeId[0].challonge_team_id
-              ? mapStats[0].team1_score
-              : mapStats[0].team2_score;
-          team2Score =
-            challongeData[correctIndex].match.player2_id ==
-            team2ChallongeId[0].challonge_team_id
-              ? mapStats[0].team2_score
-              : mapStats[0].team1_score;
-          // Build the PUT body.
-          let putBody = {
-            api_key: decryptedKey,
-            match: {
-              scores_csv: `${team1Score}-${team2Score}`,
-              winner_id:
-                winner === "team1"
-                  ? team1ChallongeId[0].challonge_team_id
-                  : team2ChallongeId[0].challonge_team_id
-            }
-          };
-          // If we're just updating the score, remove this.
-          if (winner === null) {
-            delete putBody.match.winner_id;
-          }
-          await fetch(
-            "https://api.challonge.com/v1/tournaments/" +
-              seasonInfo[0].challonge_url +
-              "/matches/" +
-              challongeData[correctIndex].match.id +
-              ".json",
-            {
-              method: "PUT",
-              headers: {
-                "Content-Type": "application/json"
-              },
-              body: JSON.stringify(putBody)
-            }
-          );
-        }
-        // Check and see if any matches remain, if not, finalize the tournament.
-        challongeResponse = await fetch(
-          "https://api.challonge.com/v1/tournaments/" +
-            seasonInfo[0].challonge_url +
-            "/matches.json?api_key=" +
-            decryptedKey +
-            "&state=open"
-        );
-        challongeData = await challongeResponse.json();
-        if (!challongeData) {
-          await fetch(
-            "https://api.challonge.com/v1/tournaments/" +
-              seasonInfo[0].challonge_url +
-              "finalize.json?api_key=" +
-              decryptedKey,
-            {
-              method: "POST"
-            }
-          );
-          // If we are the last map, let's close off the season as well.
-          sql = "UPDATE season SET end_date = ? WHERE id = ?";
-          await db.query(sql, [
-            new Date().toISOString().slice(0, 19).replace("T", " "),
-            seasonInfo[0].id
-          ]);
-          GlobalEmitter.emit("seasonUpdate");
-        }
-      }
+      if (!resp.ok) continue;
+      const body: any = await resp.json();
+      // v2.1 list response: { data: [ { id, attributes: { ... } } ] }
+      const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
+      matchData = allMatches.find(m =>
+        (m.player1_id === t1cid && m.player2_id === t2cid) ||
+        (m.player2_id === t1cid && m.player1_id === t2cid)
+      ) ?? null;
     }
+
+    if (!matchData) continue;
+
+    // Récupérer les scores
+    const scoreSql = num_maps === 1
+      ? "SELECT team1_score, team2_score FROM map_stats WHERE match_id = ?"
+      : "SELECT team1_score, team2_score FROM `match` WHERE id = ?";
+    const mapStats: RowDataPacket[] = await db.query(scoreSql, [match_id]);
+
+    // Ajuster les scores selon la position player1/player2 dans Challonge
+    const team1Score: number = matchData.player1_id === t1cid
+      ? mapStats[0].team1_score : mapStats[0].team2_score;
+    const team2Score: number = matchData.player2_id === t2cid
+      ? mapStats[0].team2_score : mapStats[0].team1_score;
+
+    // PUT v2.1 — mise à jour du score
+    await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}.json`,
+      {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(buildMatchPutBody(t1cid, t2cid, team1Score, team2Score, winner))
+      }
+    );
+
+    // Vérifier s'il reste des matchs ouverts dans CE bracket
+    const openResp = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
+      { headers }
+    );
+    const openBody: any = await openResp.json();
+    const openMatches: any[] = Array.isArray(openBody?.data) ? openBody.data : [];
+    if (openMatches.length === 0) {
+      // Finaliser ce bracket via change_state
+      await fetch(
+        `${CHALLONGE_V2_BASE}/tournaments/${slug}/change_state.json`,
+        {
+          method: "PUT",
+          headers,
+          body: JSON.stringify(buildTournamentStateBody("finalize"))
+        }
+      );
+    }
+
+    break; // match trouvé et mis à jour
+  }
+
+  // Vérifier si TOUS les brackets de la saison sont terminés pour clore la saison
+  let allFinished = true;
+  for (const slug of slugList) {
+    const openResp = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
+      { headers }
+    );
+    const openBody: any = await openResp.json();
+    const openMatches: any[] = Array.isArray(openBody?.data) ? openBody.data : [];
+    if (openMatches.length > 0) { allFinished = false; break; }
+  }
+  if (allFinished && slugList.length > 0) {
+    await db.query(
+      "UPDATE season SET end_date = ? WHERE id = ?",
+      [new Date().toISOString().slice(0, 19).replace("T", " "), seasonInfo[0].id]
+    );
+    GlobalEmitter.emit("seasonUpdate");
   }
 }

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -191,15 +191,15 @@ async function update_challonge_match(
   }
 }
 
-/** Marks a Challonge match as underway. Called when the first map goes live. */
+/** Marks a Challonge match as underway using the stored challonge_id.
+ * Tries each slug of the season in order until the PUT succeeds.
+ */
 export async function mark_challonge_match_underway(
   match_id: number | string,
-  season_id: number,
-  team1_id: number,
-  team2_id: number
+  season_id: number
 ): Promise<void> {
   const seasonInfo: RowDataPacket[] = await db.query(
-    "SELECT id, challonge_url FROM season WHERE id = ?",
+    "SELECT challonge_url FROM season WHERE id = ?",
     [season_id]
   );
   if (!seasonInfo.length) return;
@@ -208,7 +208,12 @@ export async function mark_challonge_match_underway(
   const decryptedKey = getSetting("challonge.apiKey");
   if (!decryptedKey) return;
 
-  const headers = challongeHeaders(decryptedKey);
+  const matchRow: RowDataPacket[] = await db.query(
+    "SELECT challonge_id FROM `match` WHERE id = ?",
+    [match_id]
+  );
+  const challongeMatchId: number | null = matchRow[0]?.challonge_id ?? null;
+  if (!challongeMatchId) return;
 
   const tournaments: RowDataPacket[] = await db.query(
     "SELECT challonge_slug FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC",
@@ -219,34 +224,18 @@ export async function mark_challonge_match_underway(
     : (seasonInfo[0].challonge_url ? [seasonInfo[0].challonge_url as string] : []);
   if (!slugList.length) return;
 
-  const t1Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team1_id]);
-  const t2Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team2_id]);
-  const t1cid: number = t1Row[0]?.challonge_team_id;
-  const t2cid: number = t2Row[0]?.challonge_team_id;
-  if (!t1cid || !t2cid) return;
+  const headers = challongeHeaders(decryptedKey);
 
   for (const slug of slugList) {
     const resp = await fetch(
-      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
-      { headers }
-    );
-    if (!resp.ok) continue;
-    const body: any = await resp.json();
-    const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
-    const matchData = allMatches.find(m =>
-      (m.player1_id === t1cid && m.player2_id === t2cid) ||
-      (m.player2_id === t1cid && m.player1_id === t2cid)
-    );
-    if (!matchData) continue;
-
-    await fetch(
-      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}/change_state.json`,
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}/change_state.json`,
       {
         method: "PUT",
         headers,
         body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
       }
     );
-    break;
+    if (resp.ok) break;
+    // If this slug doesn't have the match, try the next one
   }
 }

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -8,6 +8,7 @@ import {
   challongeHeaders,
   parseV2Match,
   buildMatchPutBody,
+  buildMatchStateBody,
   buildTournamentStateBody
 } from "../utility/challongeV2.js";
 
@@ -187,5 +188,65 @@ async function update_challonge_match(
       [new Date().toISOString().slice(0, 19).replace("T", " "), seasonInfo[0].id]
     );
     GlobalEmitter.emit("seasonUpdate");
+  }
+}
+
+/** Marks a Challonge match as underway. Called when the first map goes live. */
+export async function mark_challonge_match_underway(
+  match_id: number | string,
+  season_id: number,
+  team1_id: number,
+  team2_id: number
+): Promise<void> {
+  const seasonInfo: RowDataPacket[] = await db.query(
+    "SELECT id, challonge_url FROM season WHERE id = ?",
+    [season_id]
+  );
+  if (!seasonInfo.length) return;
+  if (seasonInfo[0].challonge_url?.startsWith("t:")) return;
+
+  const decryptedKey = getSetting("challonge.apiKey");
+  if (!decryptedKey) return;
+
+  const headers = challongeHeaders(decryptedKey);
+
+  const tournaments: RowDataPacket[] = await db.query(
+    "SELECT challonge_slug FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC",
+    [season_id]
+  );
+  const slugList: string[] = tournaments.length > 0
+    ? tournaments.map(t => t.challonge_slug as string)
+    : (seasonInfo[0].challonge_url ? [seasonInfo[0].challonge_url as string] : []);
+  if (!slugList.length) return;
+
+  const t1Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team1_id]);
+  const t2Row: RowDataPacket[] = await db.query("SELECT challonge_team_id FROM team WHERE id = ?", [team2_id]);
+  const t1cid: number = t1Row[0]?.challonge_team_id;
+  const t2cid: number = t2Row[0]?.challonge_team_id;
+  if (!t1cid || !t2cid) return;
+
+  for (const slug of slugList) {
+    const resp = await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches.json?state=open&per_page=500`,
+      { headers }
+    );
+    if (!resp.ok) continue;
+    const body: any = await resp.json();
+    const allMatches: any[] = Array.isArray(body?.data) ? body.data.map(parseV2Match) : [];
+    const matchData = allMatches.find(m =>
+      (m.player1_id === t1cid && m.player2_id === t2cid) ||
+      (m.player2_id === t1cid && m.player1_id === t2cid)
+    );
+    if (!matchData) continue;
+
+    await fetch(
+      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${matchData.id}/change_state.json`,
+      {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
+      }
+    );
+    break;
   }
 }

--- a/src/services/challonge.ts
+++ b/src/services/challonge.ts
@@ -198,22 +198,25 @@ export async function mark_challonge_match_underway(
   match_id: number | string,
   season_id: number
 ): Promise<void> {
+  console.log(`[Challonge] mark_underway match_id=${match_id} season_id=${season_id}`);
+
   const seasonInfo: RowDataPacket[] = await db.query(
     "SELECT challonge_url FROM season WHERE id = ?",
     [season_id]
   );
-  if (!seasonInfo.length) return;
-  if (seasonInfo[0].challonge_url?.startsWith("t:")) return;
+  if (!seasonInfo.length) { console.log("[Challonge] mark_underway: season not found"); return; }
+  if (seasonInfo[0].challonge_url?.startsWith("t:")) { console.log("[Challonge] mark_underway: toornament season, skip"); return; }
 
   const decryptedKey = getSetting("challonge.apiKey");
-  if (!decryptedKey) return;
+  if (!decryptedKey) { console.log("[Challonge] mark_underway: no API key"); return; }
 
   const matchRow: RowDataPacket[] = await db.query(
     "SELECT challonge_id FROM `match` WHERE id = ?",
     [match_id]
   );
   const challongeMatchId: number | null = matchRow[0]?.challonge_id ?? null;
-  if (!challongeMatchId) return;
+  console.log(`[Challonge] mark_underway: challonge_id=${challongeMatchId}`);
+  if (!challongeMatchId) { console.log("[Challonge] mark_underway: no challonge_id on match, abort"); return; }
 
   const tournaments: RowDataPacket[] = await db.query(
     "SELECT challonge_slug FROM season_challonge_tournament WHERE season_id = ? ORDER BY display_order ASC",
@@ -222,20 +225,22 @@ export async function mark_challonge_match_underway(
   const slugList: string[] = tournaments.length > 0
     ? tournaments.map(t => t.challonge_slug as string)
     : (seasonInfo[0].challonge_url ? [seasonInfo[0].challonge_url as string] : []);
-  if (!slugList.length) return;
+  console.log(`[Challonge] mark_underway: slugList=${JSON.stringify(slugList)}`);
+  if (!slugList.length) { console.log("[Challonge] mark_underway: no slugs, abort"); return; }
 
   const headers = challongeHeaders(decryptedKey);
 
   for (const slug of slugList) {
-    const resp = await fetch(
-      `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}/change_state.json`,
-      {
-        method: "PUT",
-        headers,
-        body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
-      }
-    );
+    const url = `${CHALLONGE_V2_BASE}/tournaments/${slug}/matches/${challongeMatchId}/change_state.json`;
+    console.log(`[Challonge] mark_underway: PUT ${url}`);
+    const resp = await fetch(url, {
+      method: "PUT",
+      headers,
+      body: JSON.stringify(buildMatchStateBody("mark_as_underway"))
+    });
+    console.log(`[Challonge] mark_underway: response status=${resp.status}`);
     if (resp.ok) break;
-    // If this slug doesn't have the match, try the next one
+    const errBody = await resp.text();
+    console.log(`[Challonge] mark_underway: error body=${errBody}`);
   }
 }

--- a/src/services/mapflowservices.ts
+++ b/src/services/mapflowservices.ts
@@ -200,11 +200,13 @@ class MapFlowService {
       await MapFlowService.setTsMatchTeams(String(event.matchid), TS_POWER.FREEZE);
 
       // Mark Challonge match as underway when the first map goes live.
+      console.log(`[Challonge] OnGoingLive matchid=${event.matchid} map_number=${event.map_number}`);
       if (event.map_number === 0) {
         const matchSeasonInfo: RowDataPacket[] = await db.query(
           "SELECT season_id FROM `match` WHERE id = ?",
           [event.matchid]
         );
+        console.log(`[Challonge] season_id=${matchSeasonInfo[0]?.season_id}`);
         if (matchSeasonInfo[0]?.season_id) {
           await mark_challonge_match_underway(event.matchid, matchSeasonInfo[0].season_id);
         }

--- a/src/services/mapflowservices.ts
+++ b/src/services/mapflowservices.ts
@@ -25,7 +25,7 @@ import { Get5_OnPlayerDeath } from "../types/map_flow/Get5_OnPlayerDeath.js";
 import { Get5_OnBombEvent } from "../types/map_flow/Get5_OnBombEvent.js";
 import { Get5_OnRoundEnd } from "../types/map_flow/Get5_OnRoundEnd.js";
 import { Get5_OnRoundStart } from "../types/map_flow/Get5_OnRoundStart.js";
-import update_challonge_match from "./challonge.js";
+import update_challonge_match, { mark_challonge_match_underway } from "./challonge.js";
 import { sendPauseEvent } from "./discord.js";
 import config from "config";
 
@@ -198,6 +198,22 @@ class MapFlowService {
 
       // TS: freeze time starting → FREEZE power
       await MapFlowService.setTsMatchTeams(String(event.matchid), TS_POWER.FREEZE);
+
+      // Mark Challonge match as underway when the first map goes live.
+      if (event.map_number === 0) {
+        const matchSeasonInfo: RowDataPacket[] = await db.query(
+          "SELECT season_id, team1_id, team2_id FROM `match` WHERE id = ?",
+          [event.matchid]
+        );
+        if (matchSeasonInfo[0]?.season_id) {
+          await mark_challonge_match_underway(
+            event.matchid,
+            matchSeasonInfo[0].season_id,
+            matchSeasonInfo[0].team1_id,
+            matchSeasonInfo[0].team2_id
+          );
+        }
+      }
 
       return res.status(200).send({ message: "Success" });
     } catch (error: unknown) {

--- a/src/services/mapflowservices.ts
+++ b/src/services/mapflowservices.ts
@@ -202,16 +202,11 @@ class MapFlowService {
       // Mark Challonge match as underway when the first map goes live.
       if (event.map_number === 0) {
         const matchSeasonInfo: RowDataPacket[] = await db.query(
-          "SELECT season_id, team1_id, team2_id FROM `match` WHERE id = ?",
+          "SELECT season_id FROM `match` WHERE id = ?",
           [event.matchid]
         );
         if (matchSeasonInfo[0]?.season_id) {
-          await mark_challonge_match_underway(
-            event.matchid,
-            matchSeasonInfo[0].season_id,
-            matchSeasonInfo[0].team1_id,
-            matchSeasonInfo[0].team2_id
-          );
+          await mark_challonge_match_underway(event.matchid, matchSeasonInfo[0].season_id);
         }
       }
 

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -45,6 +45,9 @@ const DEFAULTS: Record<string, string> = {
   "toornament.clientId": "",
   "toornament.clientSecret": "",
   "toornament.apiKey": "",
+
+  // Challonge
+  "challonge.apiKey": "",
 };
 
 // ─── Chargement initial ───────────────────────────────────────────────────────

--- a/src/types/matches/MatchData.ts
+++ b/src/types/matches/MatchData.ts
@@ -32,4 +32,6 @@ export interface MatchData {
     wingman?: boolean,
     team1_series_score?: number,
     team2_series_score?: number,
+    toornament_id?: string | null,
+    challonge_id?: number | null,
 }

--- a/src/utility/challongeV2.ts
+++ b/src/utility/challongeV2.ts
@@ -27,6 +27,8 @@ export interface NormalisedMatch {
   suggested_play_order: number | null;
   scheduled_time: string | null;
   scores_csv: string | null;
+  /** Per-set scores [[p1_set1, p2_set1], [p1_set2, p2_set2], ...] */
+  score_in_sets: number[][] | null;
   player1_id: number | null;
   player2_id: number | null;
   winner_id: number | null;
@@ -64,6 +66,9 @@ export function parseV2Match(item: any): NormalisedMatch {
     // scheduled_time may live under timestamps.scheduled_at in some versions
     scheduled_time: attr.scheduled_time ?? attr.timestamps?.scheduled_at ?? null,
     scores_csv: attr.scores ?? null,
+    score_in_sets: Array.isArray(attr.score_in_sets) && attr.score_in_sets.length > 0
+      ? attr.score_in_sets
+      : null,
     player1_id: readId("player1"),
     player2_id: readId("player2"),
     winner_id: attr.winner_id != null ? parseInt(String(attr.winner_id), 10) : null
@@ -96,15 +101,24 @@ export function buildMatchPutBody(
   winner: string | null
 ): object {
   const team1Wins = winner === "team1";
+
+  // Drop trailing 0-0 sets (unplayed maps that get5 may have created in map_stats)
+  let t1 = [...team1Scores];
+  let t2 = [...team2Scores];
+  while (t1.length > 1 && t1[t1.length - 1] === 0 && t2[t2.length - 1] === 0) {
+    t1.pop();
+    t2.pop();
+  }
+
   const matchArr: any[] = [
     {
       participant_id: String(team1ChallongeId),
-      score_set: team1Scores.join(","),
+      score_set: t1.join(","),
       ...(winner !== null && { rank: team1Wins ? 1 : 2, advancing: team1Wins })
     },
     {
       participant_id: String(team2ChallongeId),
-      score_set: team2Scores.join(","),
+      score_set: t2.join(","),
       ...(winner !== null && { rank: team1Wins ? 2 : 1, advancing: !team1Wins })
     }
   ];

--- a/src/utility/challongeV2.ts
+++ b/src/utility/challongeV2.ts
@@ -1,0 +1,112 @@
+/**
+ * Challonge API v2.1 helper utilities.
+ * Authentication: API key passed in Authorization header (Authorization-Type: v1).
+ * Base URL: https://api.challonge.com/v2.1
+ */
+
+export const CHALLONGE_V2_BASE = "https://api.challonge.com/v2.1";
+
+/** Returns the required headers for every Challonge v2.1 request (API key auth). */
+export function challongeHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Content-Type": "application/vnd.api+json",
+    "Accept": "application/json",
+    "Authorization-Type": "v1",
+    "Authorization": apiKey
+  };
+}
+
+/**
+ * Normalised match shape used internally across the codebase.
+ * Maps v2.1 JSON:API match object to a flat structure equivalent to v1.
+ */
+export interface NormalisedMatch {
+  id: number;
+  state: string;
+  round: number;
+  suggested_play_order: number | null;
+  scheduled_time: string | null;
+  scores_csv: string | null;
+  player1_id: number | null;
+  player2_id: number | null;
+  winner_id: number | null;
+}
+
+/** Parse a single v2.1 match item (from data[] or data object). */
+export function parseV2Match(item: any): NormalisedMatch {
+  const attr = item.attributes ?? {};
+  const p1id = attr.relationships?.player1?.data?.id
+    ? parseInt(attr.relationships.player1.data.id, 10)
+    : null;
+  const p2id = attr.relationships?.player2?.data?.id
+    ? parseInt(attr.relationships.player2.data.id, 10)
+    : null;
+  return {
+    id: parseInt(item.id, 10),
+    state: attr.state ?? "pending",
+    round: attr.round ?? 0,
+    suggested_play_order: attr.suggested_play_order ?? null,
+    // scheduled_time may live under timestamps.scheduled_at in some versions
+    scheduled_time: attr.scheduled_time ?? attr.timestamps?.scheduled_at ?? null,
+    scores_csv: attr.scores ?? null,
+    player1_id: p1id,
+    player2_id: p2id,
+    winner_id: attr.winner_id != null ? parseInt(String(attr.winner_id), 10) : null
+  };
+}
+
+/** Parse a single v2.1 participant item. */
+export function parseV2Participant(item: any): { id: number; display_name: string; name: string } {
+  const attr = item.attributes ?? {};
+  return {
+    id: parseInt(item.id, 10),
+    display_name: attr.name ?? "",
+    name: attr.name ?? ""
+  };
+}
+
+/**
+ * Build the v2.1 PUT body to update a match score.
+ * When winner is null, only scores are sent (intermediate update).
+ * When winner is "team1" or "team2", rank + advancing are added.
+ */
+export function buildMatchPutBody(
+  team1ChallongeId: number | string,
+  team2ChallongeId: number | string,
+  team1Score: number,
+  team2Score: number,
+  winner: string | null
+): object {
+  const team1Wins = winner === "team1";
+  const matchArr: any[] = [
+    {
+      participant_id: String(team1ChallongeId),
+      score_set: String(team1Score),
+      ...(winner !== null && { rank: team1Wins ? 1 : 2, advancing: team1Wins })
+    },
+    {
+      participant_id: String(team2ChallongeId),
+      score_set: String(team2Score),
+      ...(winner !== null && { rank: team1Wins ? 2 : 1, advancing: !team1Wins })
+    }
+  ];
+  return {
+    data: {
+      type: "Match",
+      attributes: {
+        match: matchArr,
+        tie: false
+      }
+    }
+  };
+}
+
+/** Build the v2.1 PUT body to change tournament state (e.g. finalize). */
+export function buildTournamentStateBody(state: string): object {
+  return {
+    data: {
+      type: "TournamentState",
+      attributes: { state }
+    }
+  };
+}

--- a/src/utility/challongeV2.ts
+++ b/src/utility/challongeV2.ts
@@ -144,7 +144,7 @@ export function buildTournamentStateBody(state: string): object {
 }
 
 /** Build the v2.1 PUT body to change a match state (e.g. mark_as_underway). */
-export function buildMatchStateBody(state: "mark_as_underway" | "unmark_as_underway" | "reopen"): object {
+export function buildMatchStateBody(state: "mark_as_underway" | "underway" | "unmark_as_underway" | "reopen"): object {
   return {
     data: {
       type: "MatchState",

--- a/src/utility/challongeV2.ts
+++ b/src/utility/challongeV2.ts
@@ -46,7 +46,14 @@ export function parseV2Match(item: any): NormalisedMatch {
 
   const readId = (side: "player1" | "player2"): number | null => {
     const id = rel[side]?.data?.id;
-    return id != null && id !== "" ? parseInt(String(id), 10) : null;
+    if (id != null && id !== "") return parseInt(String(id), 10);
+    // Fallback: points_by_participant (used when relationships.player1/player2 are absent)
+    if (Array.isArray(attr.points_by_participant) && attr.points_by_participant.length >= 2) {
+      const idx = side === "player1" ? 0 : 1;
+      const pid = attr.points_by_participant[idx]?.participant_id;
+      return pid != null ? parseInt(String(pid), 10) : null;
+    }
+    return null;
   };
 
   return {
@@ -75,26 +82,29 @@ export function parseV2Participant(item: any): { id: number; display_name: strin
 
 /**
  * Build the v2.1 PUT body to update a match score.
- * When winner is null, only scores are sent (intermediate update).
- * When winner is "team1" or "team2", rank + advancing are added.
+ *
+ * team1Scores / team2Scores are per-map score arrays (one entry per map played).
+ * Challonge displays them as individual sets on the bracket.
+ * When winner is null, only scores are sent (live/intermediate update).
+ * When winner is "team1" or "team2", rank + advancing are added (series end).
  */
 export function buildMatchPutBody(
   team1ChallongeId: number | string,
   team2ChallongeId: number | string,
-  team1Score: number,
-  team2Score: number,
+  team1Scores: number[],
+  team2Scores: number[],
   winner: string | null
 ): object {
   const team1Wins = winner === "team1";
   const matchArr: any[] = [
     {
       participant_id: String(team1ChallongeId),
-      score_set: String(team1Score),
+      score_set: team1Scores.join(","),
       ...(winner !== null && { rank: team1Wins ? 1 : 2, advancing: team1Wins })
     },
     {
       participant_id: String(team2ChallongeId),
-      score_set: String(team2Score),
+      score_set: team2Scores.join(","),
       ...(winner !== null && { rank: team1Wins ? 2 : 1, advancing: !team1Wins })
     }
   ];
@@ -109,11 +119,21 @@ export function buildMatchPutBody(
   };
 }
 
-/** Build the v2.1 PUT body to change tournament state (e.g. finalize). */
+/** Build the v2.1 PUT body to change tournament state (e.g. finalize, start). */
 export function buildTournamentStateBody(state: string): object {
   return {
     data: {
       type: "TournamentState",
+      attributes: { state }
+    }
+  };
+}
+
+/** Build the v2.1 PUT body to change a match state (e.g. mark_as_underway). */
+export function buildMatchStateBody(state: "mark_as_underway" | "unmark_as_underway" | "reopen"): object {
+  return {
+    data: {
+      type: "MatchState",
       attributes: { state }
     }
   };

--- a/src/utility/challongeV2.ts
+++ b/src/utility/challongeV2.ts
@@ -32,15 +32,23 @@ export interface NormalisedMatch {
   winner_id: number | null;
 }
 
-/** Parse a single v2.1 match item (from data[] or data object). */
+/** Parse a single v2.1 match item (from data[] or data object).
+ *
+ * Challonge v2.1 puts `relationships` either:
+ *  - inside `attributes` (non-standard, seen in bracket phase)
+ *  - at the root of the resource object (JSON:API standard, seen in group stage)
+ * We check both locations so both phases resolve correctly.
+ */
 export function parseV2Match(item: any): NormalisedMatch {
   const attr = item.attributes ?? {};
-  const p1id = attr.relationships?.player1?.data?.id
-    ? parseInt(attr.relationships.player1.data.id, 10)
-    : null;
-  const p2id = attr.relationships?.player2?.data?.id
-    ? parseInt(attr.relationships.player2.data.id, 10)
-    : null;
+  // Relationships: prefer root-level (JSON:API standard), fallback to inside attributes
+  const rel = item.relationships ?? attr.relationships ?? {};
+
+  const readId = (side: "player1" | "player2"): number | null => {
+    const id = rel[side]?.data?.id;
+    return id != null && id !== "" ? parseInt(String(id), 10) : null;
+  };
+
   return {
     id: parseInt(item.id, 10),
     state: attr.state ?? "pending",
@@ -49,8 +57,8 @@ export function parseV2Match(item: any): NormalisedMatch {
     // scheduled_time may live under timestamps.scheduled_at in some versions
     scheduled_time: attr.scheduled_time ?? attr.timestamps?.scheduled_at ?? null,
     scores_csv: attr.scores ?? null,
-    player1_id: p1id,
-    player2_id: p2id,
+    player1_id: readId("player1"),
+    player2_id: readId("player2"),
     winner_id: attr.winner_id != null ? parseInt(String(attr.winner_id), 10) : null
   };
 }


### PR DESCRIPTION
## Summary
- Challonge v2.1 API migration with system-wide API key and multi-bracket support
- Live per-map scores pushed to Challonge bracket
- `mark_as_underway` on `OnGoingLive` (Matchzy integration)
- Fix: wrong winner when teams are swapped in bracket
- Fix: `score_in_sets`, strip trailing 0-0 sets on push
- Fix: `public_team=1` on import, group stage match visibility
- Expose `score_in_sets`, simplify participant parsing

## Commits
- `082e6b8` feat: Challonge v2.1 API migration, multi-bracket support, system-wide API key
- `5180b99` fix: public_team=1 on Challonge import, group stage matches visibility
- `deb3e44` challonge: live per-map scores, mark_as_underway, fix participant parsing
- `31fcdb8` challonge: expose score_in_sets, strip trailing 0-0 sets on push
- `bacb872` challonge: fix wrong winner when teams are swapped in bracket
- `560ff61` → `bbfec00` challonge: mark_as_underway fixes and improvements

## Test plan
- [ ] Challonge import works with v2.1 API key
- [ ] Multi-bracket tournaments load correctly
- [ ] Live scores update in bracket during match
- [ ] `mark_as_underway` triggers on match going live
- [ ] Winner is correct when teams are swapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)