### PR TITLE
feat: map_round table + enriched backup endpoint

### DIFF
--- a/migrations/development/20260506000000-map-round.js
+++ b/migrations/development/20260506000000-map-round.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    CREATE TABLE IF NOT EXISTS map_round (
+      id           INT          NOT NULL AUTO_INCREMENT,
+      map_stats_id INT          NOT NULL,
+      round_number SMALLINT     NOT NULL,
+      winner_team  VARCHAR(10)  NOT NULL,
+      winner_side  VARCHAR(5)   NOT NULL,
+      reason       TINYINT      NOT NULL,
+      t1_score     SMALLINT     NOT NULL DEFAULT 0,
+      t2_score     SMALLINT     NOT NULL DEFAULT 0,
+      team1_side   VARCHAR(5)   NOT NULL,
+      PRIMARY KEY (id),
+      UNIQUE KEY uq_map_round (map_stats_id, round_number),
+      CONSTRAINT fk_map_round_map FOREIGN KEY (map_stats_id)
+        REFERENCES map_stats (id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`DROP TABLE IF EXISTS map_round;`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/migrations/production/20260506000000-map-round.js
+++ b/migrations/production/20260506000000-map-round.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    CREATE TABLE IF NOT EXISTS map_round (
+      id           INT          NOT NULL AUTO_INCREMENT,
+      map_stats_id INT          NOT NULL,
+      round_number SMALLINT     NOT NULL,
+      winner_team  VARCHAR(10)  NOT NULL,
+      winner_side  VARCHAR(5)   NOT NULL,
+      reason       TINYINT      NOT NULL,
+      t1_score     SMALLINT     NOT NULL DEFAULT 0,
+      t2_score     SMALLINT     NOT NULL DEFAULT 0,
+      team1_side   VARCHAR(5)   NOT NULL,
+      PRIMARY KEY (id),
+      UNIQUE KEY uq_map_round (map_stats_id, round_number),
+      CONSTRAINT fk_map_round_map FOREIGN KEY (map_stats_id)
+        REFERENCES map_stats (id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+  `);
+};
+
+exports.down = function (db) {
+  return db.runSql(`DROP TABLE IF EXISTS map_round;`);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/src/routes/matches/matchserver.ts
+++ b/src/routes/matches/matchserver.ts
@@ -15,7 +15,7 @@ import GameServer from "../../utility/serverrcon.js";
 
 import config from "config";
 
-import { existsSync, readdir, readFile } from "fs";
+import { existsSync, readdir, readFile, stat } from "fs";
 import path from "path";
 import { AccessMessage } from "../../types/mapstats/AccessMessage.js";
 import { RowDataPacket } from "mysql2";
@@ -1330,23 +1330,31 @@ router.get(
           }
           const results = await Promise.all(
             files.map(file => new Promise<object>(resolve => {
-              readFile(path.join(backupDir, file), "utf8", (readErr, content) => {
-                const base: any = { file };
-                if (!readErr && content) {
-                  const t1 = content.match(/"team1_score"\s*[:\s]+"?(\d+)/);
-                  const t2 = content.match(/"team2_score"\s*[:\s]+"?(\d+)/);
-                  const mp = content.match(/"map_name"\s*[:\s]+"?([^\s",}]+)/);
-                  const mn = file.match(/_map(\d+)_round(\d+)/);
-                  if (t1) base.team1Score = parseInt(t1[1]);
-                  if (t2) base.team2Score = parseInt(t2[1]);
-                  if (mp) base.mapName = mp[1];
-                  if (mn) { base.mapNum = parseInt(mn[1]); base.round = parseInt(mn[2]); }
-                }
-                resolve(base);
+              const filePath = path.join(backupDir, file);
+              stat(filePath, (statErr, fileStat) => {
+                const mtimeMs = !statErr ? fileStat.mtimeMs : null;
+                readFile(filePath, "utf8", (readErr, content) => {
+                  const base: any = { file, mtimeMs };
+                  if (!readErr && content) {
+                    const t1 = content.match(/"team1_score"\s*[:\s]+"?(\d+)/);
+                    const t2 = content.match(/"team2_score"\s*[:\s]+"?(\d+)/);
+                    const mp = content.match(/"map_name"\s*[:\s]+"?([^\s",}]+)/);
+                    const mn = file.match(/_map(\d+)_round(\d+)/);
+                    if (t1) base.team1Score = parseInt(t1[1]);
+                    if (t2) base.team2Score = parseInt(t2[1]);
+                    if (mp) base.mapName = mp[1];
+                    if (mn) { base.mapNum = parseInt(mn[1]); base.round = parseInt(mn[2]); }
+                  }
+                  resolve(base);
+                });
               });
             }))
           );
-          res.json({ message: "Backups retrieved.", response: results });
+          const sorted = (results as any[]).sort((a, b) => {
+            if (a.mapNum !== b.mapNum) return (a.mapNum ?? 0) - (b.mapNum ?? 0);
+            return (a.round ?? 0) - (b.round ?? 0);
+          });
+          res.json({ message: "Backups retrieved.", response: sorted });
         });
         return;
       }

--- a/src/services/mapflowservices.ts
+++ b/src/services/mapflowservices.ts
@@ -474,6 +474,32 @@ class MapFlowService {
         }
       }
 
+      // ── Round history ────────────────────────────────────────────────────
+      if (event.winner?.team && event.winner?.side) {
+        await db.query(
+          `INSERT INTO map_round
+             (map_stats_id, round_number, winner_team, winner_side, reason, t1_score, t2_score, team1_side)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON DUPLICATE KEY UPDATE
+             winner_team = VALUES(winner_team),
+             winner_side = VALUES(winner_side),
+             reason      = VALUES(reason),
+             t1_score    = VALUES(t1_score),
+             t2_score    = VALUES(t2_score),
+             team1_side  = VALUES(team1_side)`,
+          [
+            mapStatInfo[0].id,
+            event.round_number,
+            event.winner.team,
+            event.winner.side,
+            event.reason,
+            event.team1.score,
+            event.team2.score,
+            event.team1.starting_side ?? null
+          ]
+        );
+      }
+
       // ── Map stats update ─────────────────────────────────────────────────
       sqlString = "UPDATE map_stats SET ? WHERE id = ?";
       const insUpdStatement = {


### PR DESCRIPTION
## Summary

- **map_round table**: new migration creates `map_round` storing per-round data (winner team/side, CS2 reason code, scores after round, team1 side) populated on each `round_end` event
- **OnRoundEnd**: inserts/upserts into `map_round` using the corrected `winner.team` and `winner.side` from Matchzy (requires Matchzy dev PR)
- **Backup endpoint**: `GET /matches/:id/backup/remote` now returns enriched objects with `mtimeMs` (file timestamp), `mapNum`, `round`, `team1Score`, `team2Score` — sorted by map then round

## Dependencies

Requires French-CSGO/MatchZy dev → main for correct `winner.side` ("CT"/"T") and `winner.team` ("team1"/"team2") in `round_end` events.

## Test plan

- [ ] Run migration and verify `map_round` table is created
- [ ] Play a match and confirm rows are inserted after each round
- [ ] Verify `winner_team` is correct (not based on score comparison)
- [ ] Test `GET /matches/:id/backup/remote` returns timestamps and is sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)