### PR TITLE
Add MVP image generation and match/map MVP endpoints

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -58,6 +58,7 @@ app.use("/backups", express.static("public/backups"));
 app.use("/static/img/logos", express.static("public/img/logos"));
 app.use("/resource/flash/econ/tournaments/teams", express.static("public/img/logos"));
 app.use("/materials/panorama/images/tournaments/teams", express.static("public/img/logos"));
+app.use("/static/img/players", express.static("public/img/players"));
 
 
 // Security defaults with helmet

--- a/src/routes/image/generators/match.ts
+++ b/src/routes/image/generators/match.ts
@@ -12,7 +12,7 @@ async function tryLoadLogo(logoName: string | null | undefined) {
   const exts = [".png", ".svg", ".jpg", ".jpeg", ".webp"];
   const candidates = [
     ...exts.map(e => path.join(logosDir, logoName + e)),
-    path.join(logosDir, logoName),  // nom avec extension incluse
+    path.join(logosDir, logoName),
   ];
   for (const p of candidates) {
     if (fs.existsSync(p)) {
@@ -20,6 +20,28 @@ async function tryLoadLogo(logoName: string | null | undefined) {
     }
   }
   return null;
+}
+
+/** Charge un drapeau : local public/img/flags/ en priorité, sinon flagcdn.com */
+async function tryLoadFlag(flag: string | null | undefined) {
+  if (!flag) return null;
+  const code = flag.toLowerCase();
+  const flagsDir = path.join(process.cwd(), "public", "img", "flags");
+  const exts = [".png", ".svg", ".jpg"];
+  for (const ext of exts) {
+    const p = path.join(flagsDir, code + ext);
+    if (fs.existsSync(p)) {
+      try { return await loadImage(p); } catch { /* skip */ }
+    }
+  }
+  // Fallback CDN
+  try { return await loadImage(`https://flagcdn.com/w160/${code}.png`); } catch { /* skip */ }
+  return null;
+}
+
+/** Charge un logo, avec fallback sur le drapeau de l'équipe */
+async function tryLoadLogoOrFlag(logo: string | null | undefined, flag: string | null | undefined) {
+  return (await tryLoadLogo(logo)) ?? (await tryLoadFlag(flag));
 }
 
 /** Dessine un logo centré sur (cx, cy) avec une taille size×size */
@@ -39,8 +61,8 @@ export async function generateMatchImage(
 ): Promise<Buffer> {
   // Précharger les logos d'équipes
   const [logo1, logo2] = await Promise.all([
-    tryLoadLogo(match.team1_logo),
-    tryLoadLogo(match.team2_logo),
+    tryLoadLogoOrFlag(match.team1_logo, match.team1_flag),
+    tryLoadLogoOrFlag(match.team2_logo, match.team2_flag),
   ]);
   const m  = s.match;
   const W  = s.canvas.width;

--- a/src/routes/image/generators/match.ts
+++ b/src/routes/image/generators/match.ts
@@ -23,7 +23,8 @@ async function tryLoadLogo(logoName: string | null | undefined) {
 }
 
 /** Dessine un logo centré sur (cx, cy) avec une taille size×size */
-function drawLogoCentered(ctx: ReturnType<typeof createCanvas>["getContext"], img: any, cfg: LogoConfig) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function drawLogoCentered(ctx: any, img: any, cfg: LogoConfig) {
   if (!img) return;
   const half = cfg.size / 2;
   ctx.drawImage(img, cfg.x - half, cfg.y - half, cfg.size, cfg.size);
@@ -156,8 +157,8 @@ export async function generateMatchImage(
   }
 
   // ── Logos d'équipes ────────────────────────────────────────────────────────
-  if (m.team1_logo?.enabled) drawLogoCentered(ctx as any, logo1, m.team1_logo);
-  if (m.team2_logo?.enabled) drawLogoCentered(ctx as any, logo2, m.team2_logo);
+  if (m.team1_logo?.enabled) drawLogoCentered(ctx, logo1, m.team1_logo);
+  if (m.team2_logo?.enabled) drawLogoCentered(ctx, logo2, m.team2_logo);
 
   // ── Team names + series scores ──────────────────────────────────────────────
   if (m.team1_name.enabled)  drawText(ctx, team1Name,       m.team1_name.x,  m.team1_name.y,  fieldFont(m.team1_name),  m.team1_name.color);

--- a/src/routes/image/generators/match.ts
+++ b/src/routes/image/generators/match.ts
@@ -1,8 +1,33 @@
 import { createCanvas, loadImage } from "canvas";
 import path from "path";
+import fs from "fs";
 import Utils from "../../../utility/utils.js";
 import { drawText, drawMultilineText, drawRoundRect, fieldFont, tryRegisterFont } from "../helpers.js";
-import type { ImageSettings, MatchRow, MapStatRow, PlayerStatRow, PlayerWithRating } from "../types.js";
+import type { ImageSettings, LogoConfig, MatchRow, MapStatRow, PlayerStatRow, PlayerWithRating } from "../types.js";
+
+/** Charge un logo depuis public/img/logos/ — retourne null si introuvable */
+async function tryLoadLogo(logoName: string | null | undefined) {
+  if (!logoName) return null;
+  const logosDir = path.join(process.cwd(), "public", "img", "logos");
+  const exts = [".png", ".svg", ".jpg", ".jpeg", ".webp"];
+  const candidates = [
+    ...exts.map(e => path.join(logosDir, logoName + e)),
+    path.join(logosDir, logoName),  // nom avec extension incluse
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      try { return await loadImage(p); } catch { /* skip */ }
+    }
+  }
+  return null;
+}
+
+/** Dessine un logo centré sur (cx, cy) avec une taille size×size */
+function drawLogoCentered(ctx: ReturnType<typeof createCanvas>["getContext"], img: any, cfg: LogoConfig) {
+  if (!img) return;
+  const half = cfg.size / 2;
+  ctx.drawImage(img, cfg.x - half, cfg.y - half, cfg.size, cfg.size);
+}
 
 export async function generateMatchImage(
   match: MatchRow,
@@ -11,6 +36,11 @@ export async function generateMatchImage(
   players: PlayerStatRow[],
   s: ImageSettings
 ): Promise<Buffer> {
+  // Précharger les logos d'équipes
+  const [logo1, logo2] = await Promise.all([
+    tryLoadLogo(match.team1_logo),
+    tryLoadLogo(match.team2_logo),
+  ]);
   const m  = s.match;
   const W  = s.canvas.width;
   const H  = s.canvas.height;
@@ -124,6 +154,10 @@ export async function generateMatchImage(
       });
     }
   }
+
+  // ── Logos d'équipes ────────────────────────────────────────────────────────
+  if (m.team1_logo?.enabled) drawLogoCentered(ctx as any, logo1, m.team1_logo);
+  if (m.team2_logo?.enabled) drawLogoCentered(ctx as any, logo2, m.team2_logo);
 
   // ── Team names + series scores ──────────────────────────────────────────────
   if (m.team1_name.enabled)  drawText(ctx, team1Name,       m.team1_name.x,  m.team1_name.y,  fieldFont(m.team1_name),  m.team1_name.color);

--- a/src/routes/image/generators/mvp.ts
+++ b/src/routes/image/generators/mvp.ts
@@ -22,6 +22,27 @@ async function tryLoadLogo(logoName: string | null | undefined) {
   return null;
 }
 
+/** Charge un drapeau : local public/img/flags/ en priorité, sinon flagcdn.com */
+async function tryLoadFlag(flag: string | null | undefined) {
+  if (!flag) return null;
+  const code = flag.toLowerCase();
+  const flagsDir = path.join(process.cwd(), "public", "img", "flags");
+  const exts = [".png", ".svg", ".jpg"];
+  for (const ext of exts) {
+    const p = path.join(flagsDir, code + ext);
+    if (fs.existsSync(p)) {
+      try { return await loadImage(p); } catch { /* skip */ }
+    }
+  }
+  try { return await loadImage(`https://flagcdn.com/w160/${code}.png`); } catch { /* skip */ }
+  return null;
+}
+
+/** Charge un logo, avec fallback sur le drapeau de l'équipe */
+async function tryLoadLogoOrFlag(logo: string | null | undefined, flag: string | null | undefined) {
+  return (await tryLoadLogo(logo)) ?? (await tryLoadFlag(flag));
+}
+
 /** Charge une image de map depuis public/img/maps/ */
 async function tryLoadMapImage(mapName: string) {
   if (!mapName) return null;
@@ -104,8 +125,8 @@ export async function generateMapMvpImage(
 
   // ── Logos d'équipes + photo joueur ───────────────────────────────────────
   const [logo1, logo2, playerImg] = await Promise.all([
-    tryLoadLogo(match.team1_logo),
-    tryLoadLogo(match.team2_logo),
+    tryLoadLogoOrFlag(match.team1_logo, match.team1_flag),
+    tryLoadLogoOrFlag(match.team2_logo, match.team2_flag),
     cfg.player_image?.enabled ? tryLoadPlayerImage(player.steam_id) : Promise.resolve(null),
   ]);
   if (cfg.team1_logo?.enabled) drawLogoCentered(ctx, logo1, cfg.team1_logo);
@@ -114,17 +135,21 @@ export async function generateMapMvpImage(
   // ── Photo joueur ──────────────────────────────────────────────────────────
   const pi = cfg.player_image;
   if (pi?.enabled && playerImg) {
-    const half = pi.size / 2;
+    const pw = (pi.width  ?? pi.size) || pi.size;
+    const ph = (pi.height ?? pi.size) || pi.size;
+    const halfW = pw / 2;
+    const halfH = ph / 2;
     if (pi.circle) {
+      const halfR = Math.min(pw, ph) / 2;
       ctx.save();
       ctx.beginPath();
-      ctx.arc(pi.x, pi.y, half, 0, Math.PI * 2);
+      ctx.arc(pi.x, pi.y, halfR, 0, Math.PI * 2);
       ctx.closePath();
       ctx.clip();
-      (ctx as any).drawImage(playerImg, pi.x - half, pi.y - half, pi.size, pi.size);
+      (ctx as any).drawImage(playerImg, pi.x - halfW, pi.y - halfH, pw, ph);
       ctx.restore();
     } else {
-      (ctx as any).drawImage(playerImg, pi.x - half, pi.y - half, pi.size, pi.size);
+      (ctx as any).drawImage(playerImg, pi.x - halfW, pi.y - halfH, pw, ph);
     }
   }
 
@@ -166,7 +191,7 @@ export async function generateMapMvpImage(
   if (cfg.team2_name.enabled)  drawText(ctx, team2Name,                    cfg.team2_name.x,  cfg.team2_name.y,  fieldFont(cfg.team2_name),  cfg.team2_name.color);
 
   // Label MVP
-  if (cfg.mvp_label.enabled)   drawText(ctx, "★ MVP", cfg.mvp_label.x, cfg.mvp_label.y, fieldFont(cfg.mvp_label), cfg.mvp_label.color);
+  if (cfg.mvp_label.enabled)   drawText(ctx, "MVP", cfg.mvp_label.x, cfg.mvp_label.y, fieldFont(cfg.mvp_label), cfg.mvp_label.color);
 
   // Nom du joueur
   if (cfg.player_name.enabled) drawText(ctx, player.name, cfg.player_name.x, cfg.player_name.y, fieldFont(cfg.player_name), cfg.player_name.color);

--- a/src/routes/image/generators/mvp.ts
+++ b/src/routes/image/generators/mvp.ts
@@ -38,7 +38,8 @@ async function tryLoadMapImage(mapName: string) {
 }
 
 /** Dessine un logo centré sur (cx, cy) avec une taille size×size */
-function drawLogoCentered(ctx: ReturnType<typeof createCanvas>["getContext"], img: any, cfg: LogoConfig) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function drawLogoCentered(ctx: any, img: any, cfg: LogoConfig) {
   if (!img) return;
   const half = cfg.size / 2;
   ctx.drawImage(img, cfg.x - half, cfg.y - half, cfg.size, cfg.size);
@@ -92,8 +93,8 @@ export async function generateMapMvpImage(
     tryLoadLogo(match.team1_logo),
     tryLoadLogo(match.team2_logo),
   ]);
-  if (cfg.team1_logo?.enabled) drawLogoCentered(ctx as any, logo1, cfg.team1_logo);
-  if (cfg.team2_logo?.enabled) drawLogoCentered(ctx as any, logo2, cfg.team2_logo);
+  if (cfg.team1_logo?.enabled) drawLogoCentered(ctx, logo1, cfg.team1_logo);
+  if (cfg.team2_logo?.enabled) drawLogoCentered(ctx, logo2, cfg.team2_logo);
 
   // ── Graphical shapes ──────────────────────────────────────────────────────
   const sh = cfg.shapes;

--- a/src/routes/image/generators/mvp.ts
+++ b/src/routes/image/generators/mvp.ts
@@ -58,13 +58,22 @@ async function tryLoadMapImage(mapName: string) {
   return null;
 }
 
-/** Charge l'image d'un joueur depuis public/img/players/{steamId}.{ext} */
+/** Charge l'image d'un joueur depuis public/img/players/{steamId}.{ext}, fallback sur default.{ext} */
 async function tryLoadPlayerImage(steamId: string) {
-  if (!steamId) return null;
   const playersDir = path.join(process.cwd(), "public", "img", "players");
   const exts = [".png", ".jpg", ".jpeg", ".webp"];
+  // Image spécifique au joueur
+  if (steamId) {
+    for (const ext of exts) {
+      const p = path.join(playersDir, steamId + ext);
+      if (fs.existsSync(p)) {
+        try { return await loadImage(p); } catch { /* skip */ }
+      }
+    }
+  }
+  // Fallback image par défaut
   for (const ext of exts) {
-    const p = path.join(playersDir, steamId + ext);
+    const p = path.join(playersDir, "default" + ext);
     if (fs.existsSync(p)) {
       try { return await loadImage(p); } catch { /* skip */ }
     }

--- a/src/routes/image/generators/mvp.ts
+++ b/src/routes/image/generators/mvp.ts
@@ -37,6 +37,20 @@ async function tryLoadMapImage(mapName: string) {
   return null;
 }
 
+/** Charge l'image d'un joueur depuis public/img/players/{steamId}.{ext} */
+async function tryLoadPlayerImage(steamId: string) {
+  if (!steamId) return null;
+  const playersDir = path.join(process.cwd(), "public", "img", "players");
+  const exts = [".png", ".jpg", ".jpeg", ".webp"];
+  for (const ext of exts) {
+    const p = path.join(playersDir, steamId + ext);
+    if (fs.existsSync(p)) {
+      try { return await loadImage(p); } catch { /* skip */ }
+    }
+  }
+  return null;
+}
+
 /** Dessine un logo centré sur (cx, cy) avec une taille size×size */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function drawLogoCentered(ctx: any, img: any, cfg: LogoConfig) {
@@ -88,13 +102,31 @@ export async function generateMapMvpImage(
     }
   }
 
-  // ── Logos d'équipes ───────────────────────────────────────────────────────
-  const [logo1, logo2] = await Promise.all([
+  // ── Logos d'équipes + photo joueur ───────────────────────────────────────
+  const [logo1, logo2, playerImg] = await Promise.all([
     tryLoadLogo(match.team1_logo),
     tryLoadLogo(match.team2_logo),
+    cfg.player_image?.enabled ? tryLoadPlayerImage(player.steam_id) : Promise.resolve(null),
   ]);
   if (cfg.team1_logo?.enabled) drawLogoCentered(ctx, logo1, cfg.team1_logo);
   if (cfg.team2_logo?.enabled) drawLogoCentered(ctx, logo2, cfg.team2_logo);
+
+  // ── Photo joueur ──────────────────────────────────────────────────────────
+  const pi = cfg.player_image;
+  if (pi?.enabled && playerImg) {
+    const half = pi.size / 2;
+    if (pi.circle) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(pi.x, pi.y, half, 0, Math.PI * 2);
+      ctx.closePath();
+      ctx.clip();
+      (ctx as any).drawImage(playerImg, pi.x - half, pi.y - half, pi.size, pi.size);
+      ctx.restore();
+    } else {
+      (ctx as any).drawImage(playerImg, pi.x - half, pi.y - half, pi.size, pi.size);
+    }
+  }
 
   // ── Graphical shapes ──────────────────────────────────────────────────────
   const sh = cfg.shapes;

--- a/src/routes/image/generators/mvp.ts
+++ b/src/routes/image/generators/mvp.ts
@@ -1,0 +1,181 @@
+import { createCanvas, loadImage } from "canvas";
+import path from "path";
+import fs from "fs";
+import Utils from "../../../utility/utils.js";
+import { drawText, drawRoundRect, fieldFont, tryRegisterFont } from "../helpers.js";
+import type { ImageSettings, LogoConfig, PlayerStatExtended, MatchRow, MapStatRow } from "../types.js";
+
+/** Charge un logo depuis public/img/logos/ — retourne null si introuvable */
+async function tryLoadLogo(logoName: string | null | undefined) {
+  if (!logoName) return null;
+  const logosDir = path.join(process.cwd(), "public", "img", "logos");
+  const exts = [".png", ".svg", ".jpg", ".jpeg", ".webp"];
+  const candidates = [
+    ...exts.map(e => path.join(logosDir, logoName + e)),
+    path.join(logosDir, logoName),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      try { return await loadImage(p); } catch { /* skip */ }
+    }
+  }
+  return null;
+}
+
+/** Charge une image de map depuis public/img/maps/ */
+async function tryLoadMapImage(mapName: string) {
+  if (!mapName) return null;
+  const mapsDir = path.join(process.cwd(), "public", "img", "maps");
+  const exts = [".png", ".jpg", ".jpeg", ".webp"];
+  const candidates = [mapName, mapName.replace(/^de_/, ""), mapName.replace(/^cs_/, "")]
+    .flatMap(n => exts.map(e => path.join(mapsDir, n + e)));
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      try { return await loadImage(p); } catch { /* skip */ }
+    }
+  }
+  return null;
+}
+
+/** Dessine un logo centré sur (cx, cy) avec une taille size×size */
+function drawLogoCentered(ctx: ReturnType<typeof createCanvas>["getContext"], img: any, cfg: LogoConfig) {
+  if (!img) return;
+  const half = cfg.size / 2;
+  ctx.drawImage(img, cfg.x - half, cfg.y - half, cfg.size, cfg.size);
+}
+
+export async function generateMapMvpImage(
+  match: MatchRow,
+  mapRow: MapStatRow,
+  player: PlayerStatExtended,
+  s: ImageSettings
+): Promise<Buffer> {
+  const cfg = s.mvp;
+  const W   = s.canvas.width;
+  const H   = s.canvas.height;
+
+  // Enregistrement des fonts
+  tryRegisterFont(cfg.fontFile, [
+    cfg.map_name, cfg.team1_name, cfg.team1_score, cfg.team2_score, cfg.team2_name,
+    cfg.mvp_label, cfg.player_name, cfg.player_team,
+    cfg.kills, cfg.assists, cfg.deaths, cfg.rating, cfg.hs, cfg.clutches,
+  ].map(f => f.font));
+
+  const canvas = createCanvas(W, H);
+  const ctx    = canvas.getContext("2d");
+
+  // ── Background ────────────────────────────────────────────────────────────
+  let mapImgLoaded = false;
+  if (cfg.map_image?.enabled) {
+    const mapImg = await tryLoadMapImage(mapRow.map_name);
+    if (mapImg) {
+      ctx.drawImage(mapImg, 0, 0, W, H);
+      // Overlay sombre pour lisibilité
+      ctx.globalAlpha = 0.55;
+      ctx.fillStyle = "#000000";
+      ctx.fillRect(0, 0, W, H);
+      ctx.globalAlpha = 1;
+      mapImgLoaded = true;
+    }
+  }
+  if (!mapImgLoaded) {
+    try {
+      ctx.drawImage(await loadImage(path.join(process.cwd(), "public", "img", cfg.background)), 0, 0, W, H);
+    } catch {
+      ctx.fillStyle = "#1a1a2e";
+      ctx.fillRect(0, 0, W, H);
+    }
+  }
+
+  // ── Logos d'équipes ───────────────────────────────────────────────────────
+  const [logo1, logo2] = await Promise.all([
+    tryLoadLogo(match.team1_logo),
+    tryLoadLogo(match.team2_logo),
+  ]);
+  if (cfg.team1_logo?.enabled) drawLogoCentered(ctx as any, logo1, cfg.team1_logo);
+  if (cfg.team2_logo?.enabled) drawLogoCentered(ctx as any, logo2, cfg.team2_logo);
+
+  // ── Graphical shapes ──────────────────────────────────────────────────────
+  const sh = cfg.shapes;
+  if (sh.enabled) {
+    if (sh.team_pill.enabled) {
+      const tp = sh.team_pill;
+      const hw = tp.width / 2;
+      const hh = tp.height / 2;
+      if (cfg.team1_name.enabled)
+        drawRoundRect(ctx, cfg.team1_name.x - hw, cfg.team1_name.y - hh, tp.width, tp.height, tp.radius, tp.fill, tp.alpha, tp.border, tp.border_alpha, tp.border_width);
+      if (cfg.team2_name.enabled)
+        drawRoundRect(ctx, cfg.team2_name.x - hw, cfg.team2_name.y - hh, tp.width, tp.height, tp.radius, tp.fill, tp.alpha, tp.border, tp.border_alpha, tp.border_width);
+    }
+    if (sh.player_pill.enabled && cfg.player_name.enabled) {
+      const pp = sh.player_pill;
+      drawRoundRect(ctx, cfg.player_name.x - pp.width / 2, cfg.player_name.y - pp.height / 2, pp.width, pp.height, pp.radius, pp.fill, pp.alpha, pp.border, pp.border_alpha, pp.border_width);
+    }
+    if (sh.stats_bar.enabled) {
+      const sb = sh.stats_bar;
+      const statY = sb.y > 0 ? sb.y
+        : ([cfg.kills, cfg.assists, cfg.deaths, cfg.rating, cfg.hs, cfg.clutches].find(f => f.enabled)?.y ?? 620);
+      drawRoundRect(ctx, sb.x, statY - sb.height / 2, sb.width, sb.height, sb.radius, sb.fill, sb.alpha, sb.border, sb.border_alpha, sb.border_width);
+    }
+  }
+
+  // Noms d'équipes + scores
+  const team1Name = match.team1_string || match.team1_name || "Team 1";
+  const team2Name = match.team2_string || match.team2_name || "Team 2";
+
+  if (cfg.map_name.enabled) {
+    const displayMap = mapRow.map_name.replace(/^(de_|cs_|ar_)/, "").toUpperCase();
+    drawText(ctx, displayMap, cfg.map_name.x, cfg.map_name.y, fieldFont(cfg.map_name), cfg.map_name.color);
+  }
+  if (cfg.team1_name.enabled)  drawText(ctx, team1Name,                    cfg.team1_name.x,  cfg.team1_name.y,  fieldFont(cfg.team1_name),  cfg.team1_name.color);
+  if (cfg.team1_score.enabled) drawText(ctx, String(mapRow.team1_score),   cfg.team1_score.x, cfg.team1_score.y, fieldFont(cfg.team1_score), cfg.team1_score.color);
+  if (cfg.team2_score.enabled) drawText(ctx, String(mapRow.team2_score),   cfg.team2_score.x, cfg.team2_score.y, fieldFont(cfg.team2_score), cfg.team2_score.color);
+  if (cfg.team2_name.enabled)  drawText(ctx, team2Name,                    cfg.team2_name.x,  cfg.team2_name.y,  fieldFont(cfg.team2_name),  cfg.team2_name.color);
+
+  // Label MVP
+  if (cfg.mvp_label.enabled)   drawText(ctx, "★ MVP", cfg.mvp_label.x, cfg.mvp_label.y, fieldFont(cfg.mvp_label), cfg.mvp_label.color);
+
+  // Nom du joueur
+  if (cfg.player_name.enabled) drawText(ctx, player.name, cfg.player_name.x, cfg.player_name.y, fieldFont(cfg.player_name), cfg.player_name.color);
+
+  // Équipe du joueur
+  if (cfg.player_team.enabled) {
+    const isTeam1 = player.team_id === match.team1_id;
+    drawText(ctx, isTeam1 ? team1Name : team2Name, cfg.player_team.x, cfg.player_team.y, fieldFont(cfg.player_team), cfg.player_team.color);
+  }
+
+  // Calcul des stats
+  const kills    = Number(player.kills);
+  const deaths   = Number(player.deaths);
+  const assists  = Number(player.assists);
+  const rounds   = Number(player.roundsplayed);
+  const hsk      = Number(player.headshot_kills);
+  const clutches = Number(player.v1) + Number(player.v2) + Number(player.v3) + Number(player.v4) + Number(player.v5);
+  const rating   = Utils.getRating(
+    kills, rounds, deaths,
+    Number(player.k1), Number(player.k2), Number(player.k3), Number(player.k4), Number(player.k5)
+  );
+  const hsp = kills > 0 ? Math.round((hsk / kills) * 100) : 0;
+
+  // ── En-têtes de colonnes ──────────────────────────────────────────────────
+  const ch = cfg.column_headers;
+  if (ch.enabled) {
+    const chFont = `${ch.bold ? "bold " : ""}${ch.size}px ${ch.font}`;
+    if (ch.kills_label)    drawText(ctx, ch.kills_label,    cfg.kills.x,    ch.y,  chFont, ch.color);
+    if (ch.assists_label)  drawText(ctx, ch.assists_label,  cfg.assists.x,  ch.y,  chFont, ch.color);
+    if (ch.deaths_label)   drawText(ctx, ch.deaths_label,   cfg.deaths.x,   ch.y,  chFont, ch.color);
+    if (ch.rating_label)   drawText(ctx, ch.rating_label,   cfg.rating.x,   ch.y2, chFont, ch.color);
+    if (ch.hs_label)       drawText(ctx, ch.hs_label,       cfg.hs.x,       ch.y2, chFont, ch.color);
+    if (ch.clutches_label) drawText(ctx, ch.clutches_label, cfg.clutches.x, ch.y2, chFont, ch.color);
+  }
+
+  // ── Stats ─────────────────────────────────────────────────────────────────
+  if (cfg.kills.enabled)    drawText(ctx, String(kills),    cfg.kills.x,    cfg.kills.y,    fieldFont(cfg.kills),    cfg.kills.color);
+  if (cfg.assists.enabled)  drawText(ctx, String(assists),  cfg.assists.x,  cfg.assists.y,  fieldFont(cfg.assists),  cfg.assists.color);
+  if (cfg.deaths.enabled)   drawText(ctx, String(deaths),   cfg.deaths.x,   cfg.deaths.y,   fieldFont(cfg.deaths),   cfg.deaths.color);
+  if (cfg.rating.enabled)   drawText(ctx, String(rating),   cfg.rating.x,   cfg.rating.y,   fieldFont(cfg.rating),   cfg.rating.color);
+  if (cfg.hs.enabled)       drawText(ctx, `${hsp}%`,        cfg.hs.x,       cfg.hs.y,       fieldFont(cfg.hs),       cfg.hs.color);
+  if (cfg.clutches.enabled) drawText(ctx, String(clutches), cfg.clutches.x, cfg.clutches.y, fieldFont(cfg.clutches), cfg.clutches.color);
+
+  return canvas.toBuffer("image/png");
+}

--- a/src/routes/image/image.ts
+++ b/src/routes/image/image.ts
@@ -115,6 +115,38 @@ router.post(
   }
 );
 
+/** GET /image/players — liste les images de joueurs dans public/img/players/ */
+router.get("/players", (_req: Request, res: Response) => {
+  const playersDir = path.join(process.cwd(), "public", "img", "players");
+  try {
+    const files = fs.existsSync(playersDir)
+      ? fs.readdirSync(playersDir).filter(f => /\.(png|jpg|jpeg|webp)$/i.test(f))
+      : [];
+    res.json(files);
+  } catch {
+    res.json([]);
+  }
+});
+
+/** POST /image/upload/player — upload d'une image joueur dans public/img/players/{steamid}.png */
+router.post(
+  "/upload/player",
+  upload.single("file") as any,
+  (req: MReq, res: Response) => {
+    if (!req.file) { res.status(400).json({ error: "No file received." }); return; }
+    const steamId = (req as any).body?.steam_id as string | undefined;
+    if (!steamId || !/^\d{17}$/.test(steamId)) {
+      res.status(400).json({ error: "Invalid or missing steam_id (must be 17 digits)." });
+      return;
+    }
+    const playersDir = path.join(process.cwd(), "public", "img", "players");
+    if (!fs.existsSync(playersDir)) fs.mkdirSync(playersDir, { recursive: true });
+    const dest = path.join(playersDir, `${steamId}.png`);
+    writeFileSafe(dest, req.file.buffer);
+    res.json({ filename: `${steamId}.png` });
+  }
+);
+
 /** POST /image/upload/font — sauvegarde un fichier dans public/fonts/ */
 router.post(
   "/upload/font",

--- a/src/routes/image/image.ts
+++ b/src/routes/image/image.ts
@@ -209,7 +209,8 @@ async function renderMatchImage(req: Request, res: Response, mapParam: number | 
     const matchRows = await db.query(
       `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
               t1.name AS team1_name, t2.name AS team2_name,
-              t1.logo AS team1_logo, t2.logo AS team2_logo
+              t1.logo AS team1_logo, t2.logo AS team2_logo,
+              t1.flag AS team1_flag, t2.flag AS team2_flag
        FROM \`match\` m
        LEFT JOIN team t1 ON t1.id = m.team1_id
        LEFT JOIN team t2 ON t2.id = m.team2_id
@@ -301,7 +302,8 @@ async function renderMvpImage(req: Request, res: Response) {
     const matchRows = await db.query(
       `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
               t1.name AS team1_name, t2.name AS team2_name,
-              t1.logo AS team1_logo, t2.logo AS team2_logo
+              t1.logo AS team1_logo, t2.logo AS team2_logo,
+              t1.flag AS team1_flag, t2.flag AS team2_flag
        FROM \`match\` m
        LEFT JOIN team t1 ON t1.id = m.team1_id
        LEFT JOIN team t2 ON t2.id = m.team2_id
@@ -381,7 +383,8 @@ async function renderPlayerImage(req: Request, res: Response, mapNumber: number 
     const matchRows = await db.query(
       `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
               t1.name AS team1_name, t2.name AS team2_name,
-              t1.logo AS team1_logo, t2.logo AS team2_logo
+              t1.logo AS team1_logo, t2.logo AS team2_logo,
+              t1.flag AS team1_flag, t2.flag AS team2_flag
        FROM \`match\` m
        LEFT JOIN team t1 ON t1.id = m.team1_id
        LEFT JOIN team t2 ON t2.id = m.team2_id

--- a/src/routes/image/image.ts
+++ b/src/routes/image/image.ts
@@ -12,9 +12,11 @@ import fs from "fs";
 import { db } from "../../services/db.js";
 import { upload, writeFileSafe } from "./helpers.js";
 import { loadSettings, saveSettings } from "./settings.js";
+import Utils from "../../utility/utils.js";
 import { generateMatchImage } from "./generators/match.js";
 import { generatePlayerImage } from "./generators/player.js";
 import { generateTeamSeasonImage } from "./generators/teamSeason.js";
+import { generateMapMvpImage } from "./generators/mvp.js";
 import type { ImageSettings } from "./types.js";
 import type {
   MatchRow, MapStatRow, PlayerStatRow,
@@ -206,7 +208,8 @@ async function renderMatchImage(req: Request, res: Response, mapParam: number | 
 
     const matchRows = await db.query(
       `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
-              t1.name AS team1_name, t2.name AS team2_name
+              t1.name AS team1_name, t2.name AS team2_name,
+              t1.logo AS team1_logo, t2.logo AS team2_logo
        FROM \`match\` m
        LEFT JOIN team t1 ON t1.id = m.team1_id
        LEFT JOIN team t2 ON t2.id = m.team2_id
@@ -281,6 +284,80 @@ async function renderMatchImage(req: Request, res: Response, mapParam: number | 
   }
 }
 
+// ─── MVP image route ──────────────────────────────────────────────────────────
+
+/** GET /image/match/:match_id/map/:map_number/mvp — image MVP de la map */
+router.get("/match/:match_id/map/:map_number/mvp", async (req: Request, res: Response) => {
+  await renderMvpImage(req, res);
+});
+
+async function renderMvpImage(req: Request, res: Response) {
+  try {
+    const matchId  = parseInt(req.params.match_id);
+    const mapNumber = parseInt(req.params.map_number);
+    if (isNaN(matchId))               { res.status(400).json({ error: "Invalid match ID" }); return; }
+    if (isNaN(mapNumber) || mapNumber < 1) { res.status(400).json({ error: "Invalid map number" }); return; }
+
+    const matchRows = await db.query(
+      `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
+              t1.name AS team1_name, t2.name AS team2_name,
+              t1.logo AS team1_logo, t2.logo AS team2_logo
+       FROM \`match\` m
+       LEFT JOIN team t1 ON t1.id = m.team1_id
+       LEFT JOIN team t2 ON t2.id = m.team2_id
+       WHERE m.id = ?`,
+      [matchId]
+    ) as MatchRow[];
+    if (!matchRows?.length) { res.status(404).json({ error: "Match not found" }); return; }
+
+    // Resolve map_number (1-indexed) to map_stats row
+    const mapRows = await db.query(
+      `SELECT id, map_name, team1_score, team2_score FROM map_stats WHERE match_id = ? AND map_number = ? LIMIT 1`,
+      [matchId, mapNumber - 1]
+    ) as MapStatRow[];
+    if (!mapRows?.length) { res.status(404).json({ error: `Map ${mapNumber} not found for this match` }); return; }
+    const mapRow = mapRows[0];
+
+    // Fetch all players' extended stats for this specific map
+    const players = await db.query(
+      `SELECT steam_id, name, team_id,
+         SUM(kills)          AS kills,
+         SUM(deaths)         AS deaths,
+         SUM(assists)        AS assists,
+         SUM(roundsplayed)   AS roundsplayed,
+         SUM(headshot_kills) AS headshot_kills,
+         SUM(k1) AS k1, SUM(k2) AS k2, SUM(k3) AS k3, SUM(k4) AS k4, SUM(k5) AS k5,
+         SUM(v1) AS v1, SUM(v2) AS v2, SUM(v3) AS v3, SUM(v4) AS v4, SUM(v5) AS v5
+       FROM player_stats
+       WHERE match_id = ? AND map_id = ?
+       GROUP BY steam_id, team_id`,
+      [matchId, mapRow.id]
+    ) as PlayerStatExtended[];
+    if (!players?.length) { res.status(404).json({ error: "No player stats found for this map" }); return; }
+
+    // MVP = player with highest HLTV 2.0 rating
+    const mvpPlayer = players.reduce((best, p) => {
+      const r = Utils.getRating(
+        Number(p.kills), Number(p.roundsplayed), Number(p.deaths),
+        Number(p.k1), Number(p.k2), Number(p.k3), Number(p.k4), Number(p.k5)
+      );
+      const rBest = Utils.getRating(
+        Number(best.kills), Number(best.roundsplayed), Number(best.deaths),
+        Number(best.k1), Number(best.k2), Number(best.k3), Number(best.k4), Number(best.k5)
+      );
+      return r > rBest ? p : best;
+    });
+
+    const png = await generateMapMvpImage(matchRows[0], mapRow, mvpPlayer, loadSettings());
+    res.setHeader("Content-Type", "image/png");
+    res.setHeader("Cache-Control", "no-cache, no-store");
+    res.send(png);
+  } catch (err) {
+    console.error("[image/mvp] Error:", err);
+    res.status(500).json({ error: "Failed to generate MVP image" });
+  }
+}
+
 // ─── Player image routes ──────────────────────────────────────────────────────
 
 /** GET /image/match/:match_id/player/:steam_id — stats joueur sur tout le match */
@@ -303,7 +380,8 @@ async function renderPlayerImage(req: Request, res: Response, mapNumber: number 
 
     const matchRows = await db.query(
       `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
-              t1.name AS team1_name, t2.name AS team2_name
+              t1.name AS team1_name, t2.name AS team2_name,
+              t1.logo AS team1_logo, t2.logo AS team2_logo
        FROM \`match\` m
        LEFT JOIN team t1 ON t1.id = m.team1_id
        LEFT JOIN team t2 ON t2.id = m.team2_id

--- a/src/routes/image/image.ts
+++ b/src/routes/image/image.ts
@@ -285,12 +285,98 @@ async function renderMatchImage(req: Request, res: Response, mapParam: number | 
   }
 }
 
-// ─── MVP image route ──────────────────────────────────────────────────────────
+// ─── MVP image routes ─────────────────────────────────────────────────────────
+
+/** GET /image/match/:match_id/mvp — image MVP du match complet (stats agrégées toutes maps) */
+router.get("/match/:match_id/mvp", async (req: Request, res: Response) => {
+  await renderFullMatchMvpImage(req, res);
+});
 
 /** GET /image/match/:match_id/map/:map_number/mvp — image MVP de la map */
 router.get("/match/:match_id/map/:map_number/mvp", async (req: Request, res: Response) => {
   await renderMvpImage(req, res);
 });
+
+async function renderFullMatchMvpImage(req: Request, res: Response) {
+  try {
+    const matchId = parseInt(req.params.match_id);
+    if (isNaN(matchId)) { res.status(400).json({ error: "Invalid match ID" }); return; }
+
+    const matchRows = await db.query(
+      `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
+              t1.name AS team1_name, t2.name AS team2_name,
+              t1.logo AS team1_logo, t2.logo AS team2_logo,
+              t1.flag AS team1_flag, t2.flag AS team2_flag
+       FROM \`match\` m
+       LEFT JOIN team t1 ON t1.id = m.team1_id
+       LEFT JOIN team t2 ON t2.id = m.team2_id
+       WHERE m.id = ?`,
+      [matchId]
+    ) as MatchRow[];
+    if (!matchRows?.length) { res.status(404).json({ error: "Match not found" }); return; }
+
+    // All maps for series score
+    const allMaps = await db.query(
+      `SELECT id, map_name, team1_score, team2_score FROM map_stats WHERE match_id = ? ORDER BY map_number ASC`,
+      [matchId]
+    ) as MapStatRow[];
+    if (!allMaps?.length) { res.status(404).json({ error: "No maps found for this match" }); return; }
+
+    // Series score (maps won)
+    const t1Score = allMaps.filter(r => r.team1_score > r.team2_score).length;
+    const t2Score = allMaps.filter(r => r.team2_score > r.team1_score).length;
+
+    // Synthesize a "mapRow" representing the full match
+    const syntheticMap: MapStatRow = {
+      id:          0,
+      map_name:    "match",
+      team1_score: t1Score,
+      team2_score: t2Score,
+    } as MapStatRow;
+
+    // Aggregate player stats across all maps
+    const players = await db.query(
+      `SELECT steam_id, name, team_id,
+         SUM(kills)          AS kills,
+         SUM(deaths)         AS deaths,
+         SUM(assists)        AS assists,
+         SUM(roundsplayed)   AS roundsplayed,
+         SUM(headshot_kills) AS headshot_kills,
+         SUM(k1) AS k1, SUM(k2) AS k2, SUM(k3) AS k3, SUM(k4) AS k4, SUM(k5) AS k5,
+         SUM(v1) AS v1, SUM(v2) AS v2, SUM(v3) AS v3, SUM(v4) AS v4, SUM(v5) AS v5
+       FROM player_stats
+       WHERE match_id = ?
+       GROUP BY steam_id, team_id`,
+      [matchId]
+    ) as PlayerStatExtended[];
+    if (!players?.length) { res.status(404).json({ error: "No player stats found for this match" }); return; }
+
+    // MVP = player with highest HLTV 2.0 rating (aggregated)
+    const mvpPlayer = players.reduce((best, p) => {
+      const r = Utils.getRating(
+        Number(p.kills), Number(p.roundsplayed), Number(p.deaths),
+        Number(p.k1), Number(p.k2), Number(p.k3), Number(p.k4), Number(p.k5)
+      );
+      const rBest = Utils.getRating(
+        Number(best.kills), Number(best.roundsplayed), Number(best.deaths),
+        Number(best.k1), Number(best.k2), Number(best.k3), Number(best.k4), Number(best.k5)
+      );
+      return r > rBest ? p : best;
+    });
+
+    // Disable map image for full-match MVP (no single map background)
+    const settings = loadSettings();
+    settings.mvp.map_image = { enabled: false };
+
+    const png = await generateMapMvpImage(matchRows[0], syntheticMap, mvpPlayer, settings);
+    res.setHeader("Content-Type", "image/png");
+    res.setHeader("Cache-Control", "no-cache, no-store");
+    res.send(png);
+  } catch (err) {
+    console.error("[image/mvp-match] Error:", err);
+    res.status(500).json({ error: "Failed to generate full match MVP image" });
+  }
+}
 
 async function renderMvpImage(req: Request, res: Response) {
   try {

--- a/src/routes/image/settings.ts
+++ b/src/routes/image/settings.ts
@@ -112,7 +112,7 @@ export const DEFAULT_SETTINGS: ImageSettings = {
       rating_label: "RTG", hs_label: "HS%", clutches_label: "CL",
     },
     map_image:    { enabled: true },
-    player_image: { enabled: true, x: 960, y: 480, size: 120, circle: true },
+    player_image: { enabled: true, x: 960, y: 480, size: 120, width: 120, height: 200, circle: false },
     shapes: {
       enabled: false,
       team_pill: {

--- a/src/routes/image/settings.ts
+++ b/src/routes/image/settings.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import type { FC, FX, ImageSettings } from "./types.js";
+import type { FC, FX, LogoConfig, ImageSettings } from "./types.js";
 
 export const SETTINGS_PATH = path.join(process.cwd(), "public", "image-settings.json");
 
@@ -9,6 +9,9 @@ export const fc = (enabled: boolean, font: string, color: string, size: number, 
 
 export const fx = (enabled: boolean, font: string, color: string, size: number, bold: boolean, x: number): FX =>
   ({ enabled, font, color, size, bold, x });
+
+export const logo = (enabled: boolean, x: number, y: number, size: number): LogoConfig =>
+  ({ enabled, x, y, size });
 
 export const DEFAULT_SETTINGS: ImageSettings = {
   canvas: { width: 1920, height: 1080 },
@@ -32,6 +35,8 @@ export const DEFAULT_SETTINGS: ImageSettings = {
     assists_r:     fx(true, "Arial", "#1a1a2e", 20, false, 1105),
     deaths_r:      fx(true, "Arial", "#1a1a2e", 20, false, 1195),
     rating_r:      fx(true, "Arial", "#1a1a2e", 20, false, 1280),
+    team1_logo: logo(true,  310, 302, 60),
+    team2_logo: logo(true, 1610, 302, 60),
     column_headers: {
       enabled: false, y: 400,
       font: "Arial", color: "#1a1a2e", size: 20, bold: true,
@@ -77,6 +82,49 @@ export const DEFAULT_SETTINGS: ImageSettings = {
         odd_alpha:  0.08,
         even_fill:  "#ffffff",
         even_alpha: 0.05,
+      },
+    },
+  },
+
+  mvp: {
+    background:   "marble.png",
+    fontFile:     "",
+    map_name:     fc(true, "Arial", "#ffffff", 22, false, 960, 80),
+    team1_name:   fc(true, "Arial", "#ffffff", 32, true, 450, 200),
+    team1_score:  fc(true, "Arial", "#ffffff", 32, true, 800, 200),
+    team2_score:  fc(true, "Arial", "#ffffff", 32, true, 1120, 200),
+    team2_name:   fc(true, "Arial", "#ffffff", 32, true, 1470, 200),
+    mvp_label:    fc(true, "Arial", "#f4d03f", 28, true, 960, 310),
+    player_name:  fc(true, "Arial", "#ffffff", 52, true, 960, 390),
+    player_team:  fc(true, "Arial", "#cccccc", 22, false, 960, 450),
+    kills:        fc(true, "Arial", "#ffffff", 28, false, 500,  620),
+    assists:      fc(true, "Arial", "#ffffff", 28, false, 700,  620),
+    deaths:       fc(true, "Arial", "#ffffff", 28, false, 900,  620),
+    rating:       fc(true, "Arial", "#ffffff", 28, false, 1100, 620),
+    hs:           fc(true, "Arial", "#ffffff", 28, false, 1310, 620),
+    clutches:     fc(true, "Arial", "#ffffff", 28, false, 1500, 620),
+    team1_logo:   logo(true,  310, 200, 70),
+    team2_logo:   logo(true, 1610, 200, 70),
+    column_headers: {
+      enabled: false, y: 550, y2: 550,
+      font: "Arial", color: "#cccccc", size: 18, bold: true,
+      kills_label: "K", assists_label: "A", deaths_label: "D",
+      rating_label: "RTG", hs_label: "HS%", clutches_label: "CL",
+    },
+    map_image: { enabled: true },
+    shapes: {
+      enabled: false,
+      team_pill: {
+        enabled: true, fill: "#000000", alpha: 0.4, radius: 50,
+        width: 420, height: 65, border: "#ffffff", border_alpha: 0.25, border_width: 2,
+      },
+      player_pill: {
+        enabled: true, fill: "#000000", alpha: 0.4, radius: 50,
+        width: 680, height: 75, border: "#ffffff", border_alpha: 0.2, border_width: 2,
+      },
+      stats_bar: {
+        enabled: true, fill: "#000000", alpha: 0.3, radius: 22,
+        x: 420, y: 0, width: 1140, height: 70, border: "#ffffff", border_alpha: 0.1, border_width: 1,
       },
     },
   },
@@ -240,9 +288,11 @@ export function loadSettings(): ImageSettings {
     const dm  = DEFAULT_SETTINGS.match;
     const dp  = DEFAULT_SETTINGS.player;
     const dt  = DEFAULT_SETTINGS.team_season;
+    const dv  = DEFAULT_SETTINGS.mvp;
     const sm  = p.match       ?? {};
     const sp  = p.player      ?? {};
     const st  = p.team_season ?? {};
+    const sv  = p.mvp         ?? {};
     return {
       canvas: { ...DEFAULT_SETTINGS.canvas, ...(p.canvas ?? {}) },
       match: {
@@ -264,6 +314,8 @@ export function loadSettings(): ImageSettings {
         assists_r:      mergeFX(dm.assists_r,      sm.assists_r),
         deaths_r:       mergeFX(dm.deaths_r,       sm.deaths_r),
         rating_r:       mergeFX(dm.rating_r,       sm.rating_r),
+        team1_logo:     { ...dm.team1_logo, ...(sm.team1_logo ?? {}) },
+        team2_logo:     { ...dm.team2_logo, ...(sm.team2_logo ?? {}) },
         column_headers: { ...dm.column_headers, ...(sm.column_headers ?? {}) },
         shapes: {
           ...dm.shapes,
@@ -293,6 +345,35 @@ export function loadSettings(): ImageSettings {
           team_pill:   { ...dp.shapes.team_pill,   ...(sp.shapes?.team_pill   ?? {}) },
           player_pill: { ...dp.shapes.player_pill, ...(sp.shapes?.player_pill ?? {}) },
           stats_bar:   { ...dp.shapes.stats_bar,   ...(sp.shapes?.stats_bar   ?? {}) },
+        },
+      },
+      mvp: {
+        background:   sv.background ?? dv.background,
+        fontFile:     sv.fontFile   ?? dv.fontFile,
+        map_name:     mergeFC(dv.map_name,    sv.map_name),
+        team1_name:   mergeFC(dv.team1_name,  sv.team1_name),
+        team1_score:  mergeFC(dv.team1_score, sv.team1_score),
+        team2_score:  mergeFC(dv.team2_score, sv.team2_score),
+        team2_name:   mergeFC(dv.team2_name,  sv.team2_name),
+        mvp_label:    mergeFC(dv.mvp_label,   sv.mvp_label),
+        player_name:  mergeFC(dv.player_name, sv.player_name),
+        player_team:  mergeFC(dv.player_team, sv.player_team),
+        kills:        mergeFC(dv.kills,       sv.kills),
+        assists:      mergeFC(dv.assists,     sv.assists),
+        deaths:       mergeFC(dv.deaths,      sv.deaths),
+        rating:       mergeFC(dv.rating,      sv.rating),
+        hs:           mergeFC(dv.hs,          sv.hs),
+        clutches:     mergeFC(dv.clutches,    sv.clutches),
+        team1_logo:   { ...dv.team1_logo, ...(sv.team1_logo ?? {}) },
+        team2_logo:   { ...dv.team2_logo, ...(sv.team2_logo ?? {}) },
+        column_headers: { ...dv.column_headers, ...(sv.column_headers ?? {}) },
+        map_image:    { ...dv.map_image,    ...(sv.map_image    ?? {}) },
+        shapes: {
+          ...dv.shapes,
+          ...(sv.shapes ?? {}),
+          team_pill:   { ...dv.shapes.team_pill,   ...(sv.shapes?.team_pill   ?? {}) },
+          player_pill: { ...dv.shapes.player_pill, ...(sv.shapes?.player_pill ?? {}) },
+          stats_bar:   { ...dv.shapes.stats_bar,   ...(sv.shapes?.stats_bar   ?? {}) },
         },
       },
       team_season: {

--- a/src/routes/image/settings.ts
+++ b/src/routes/image/settings.ts
@@ -111,7 +111,8 @@ export const DEFAULT_SETTINGS: ImageSettings = {
       kills_label: "K", assists_label: "A", deaths_label: "D",
       rating_label: "RTG", hs_label: "HS%", clutches_label: "CL",
     },
-    map_image: { enabled: true },
+    map_image:    { enabled: true },
+    player_image: { enabled: true, x: 960, y: 480, size: 120, circle: true },
     shapes: {
       enabled: false,
       team_pill: {
@@ -368,6 +369,7 @@ export function loadSettings(): ImageSettings {
         team2_logo:   { ...dv.team2_logo, ...(sv.team2_logo ?? {}) },
         column_headers: { ...dv.column_headers, ...(sv.column_headers ?? {}) },
         map_image:    { ...dv.map_image,    ...(sv.map_image    ?? {}) },
+        player_image: { ...dv.player_image, ...(sv.player_image ?? {}) },
         shapes: {
           ...dv.shapes,
           ...(sv.shapes ?? {}),

--- a/src/routes/image/types.ts
+++ b/src/routes/image/types.ts
@@ -206,7 +206,9 @@ export interface ImageSettings {
       enabled: boolean;
       x:       number;   // centre X
       y:       number;   // centre Y
-      size:    number;
+      size:    number;   // fallback if width/height not set
+      width:   number;   // largeur (rectangle)
+      height:  number;   // hauteur (rectangle)
       circle:  boolean;  // découpe circulaire
     };
     shapes: {
@@ -347,6 +349,7 @@ export interface MatchRow extends RowDataPacket {
   team1_string: string | null; team2_string: string | null;
   team1_name: string | null;   team2_name: string | null;
   team1_logo: string | null;   team2_logo: string | null;
+  team1_flag: string | null;   team2_flag: string | null;
 }
 export interface MapStatRow extends RowDataPacket {
   id: number; map_name: string;

--- a/src/routes/image/types.ts
+++ b/src/routes/image/types.ts
@@ -202,6 +202,13 @@ export interface ImageSettings {
     team2_logo:   LogoConfig;
     column_headers: PlayerColumnHeaders;
     map_image:    { enabled: boolean; };
+    player_image: {
+      enabled: boolean;
+      x:       number;   // centre X
+      y:       number;   // centre Y
+      size:    number;
+      circle:  boolean;  // découpe circulaire
+    };
     shapes: {
       enabled:     boolean;
       team_pill: {

--- a/src/routes/image/types.ts
+++ b/src/routes/image/types.ts
@@ -50,6 +50,14 @@ export interface PlayerColumnHeaders {
   clutches_label:  string;
 }
 
+/** Position + size d'un logo d'équipe */
+export interface LogoConfig {
+  enabled: boolean;
+  x:       number;   // centre X
+  y:       number;   // centre Y
+  size:    number;   // taille (largeur = hauteur)
+}
+
 export interface ImageSettings {
   canvas: { width: number; height: number };
 
@@ -72,6 +80,8 @@ export interface ImageSettings {
     assists_r: FX;
     deaths_r:  FX;
     rating_r:  FX;
+    team1_logo: LogoConfig;
+    team2_logo: LogoConfig;
     column_headers: MatchColumnHeaders;
     shapes: {
       enabled:           boolean;
@@ -131,6 +141,67 @@ export interface ImageSettings {
     hs:       FC;
     clutches: FC;
     column_headers: PlayerColumnHeaders;
+    shapes: {
+      enabled:     boolean;
+      team_pill: {
+        enabled:      boolean;
+        fill:         string;
+        alpha:        number;
+        radius:       number;
+        width:        number;
+        height:       number;
+        border:       string;
+        border_alpha: number;
+        border_width: number;
+      };
+      player_pill: {
+        enabled:      boolean;
+        fill:         string;
+        alpha:        number;
+        radius:       number;
+        width:        number;
+        height:       number;
+        border:       string;
+        border_alpha: number;
+        border_width: number;
+      };
+      stats_bar: {
+        enabled:      boolean;
+        fill:         string;
+        alpha:        number;
+        radius:       number;
+        x:            number;
+        y:            number;
+        width:        number;
+        height:       number;
+        border:       string;
+        border_alpha: number;
+        border_width: number;
+      };
+    };
+  };
+
+  mvp: {
+    background:   string;
+    fontFile:     string;
+    map_name:     FC;
+    team1_name:   FC;
+    team1_score:  FC;
+    team2_score:  FC;
+    team2_name:   FC;
+    mvp_label:    FC;
+    player_name:  FC;
+    player_team:  FC;
+    kills:        FC;
+    assists:      FC;
+    deaths:       FC;
+    rating:       FC;
+    hs:           FC;
+    clutches:     FC;
+    team1_logo:   LogoConfig;
+    team2_logo:   LogoConfig;
+    column_headers: PlayerColumnHeaders;
+    map_image:    { enabled: boolean; };
     shapes: {
       enabled:     boolean;
       team_pill: {
@@ -268,6 +339,7 @@ export interface MatchRow extends RowDataPacket {
   team1_id: number; team2_id: number;
   team1_string: string | null; team2_string: string | null;
   team1_name: string | null;   team2_name: string | null;
+  team1_logo: string | null;   team2_logo: string | null;
 }
 export interface MapStatRow extends RowDataPacket {
   id: number; map_name: string;

--- a/src/routes/mapstats.ts
+++ b/src/routes/mapstats.ts
@@ -644,4 +644,224 @@ router.get("/:match_id/:map_number/overtime", async (req, res) => {
   }
 });
 
+/** GET /mapstats/:match_id/mvp — Best player (by HLTV rating) for the entire match */
+router.get("/:match_id/mvp", async (req, res) => {
+  try {
+    const matchId = parseInt(req.params.match_id);
+    if (isNaN(matchId)) {
+      res.status(400).json({ message: "Invalid match_id" });
+      return;
+    }
+
+    const matchRows: RowDataPacket[] = await db.query(
+      `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
+              t1.name AS team1_name, t1.logo AS team1_logo,
+              t2.name AS team2_name, t2.logo AS team2_logo
+       FROM \`match\` m
+       LEFT JOIN team t1 ON t1.id = m.team1_id
+       LEFT JOIN team t2 ON t2.id = m.team2_id
+       WHERE m.id = ?`,
+      [matchId]
+    );
+
+    if (!matchRows.length) {
+      res.status(404).json({ message: "Match not found" });
+      return;
+    }
+
+    const players: RowDataPacket[] = await db.query(
+      `SELECT ps.steam_id, ps.name, ps.team_id,
+         SUM(ps.kills) AS kills, SUM(ps.deaths) AS deaths, SUM(ps.assists) AS assists,
+         SUM(ps.roundsplayed) AS roundsplayed, SUM(ps.headshot_kills) AS headshot_kills,
+         SUM(ps.damage) AS damage,
+         SUM(ps.k1) AS k1, SUM(ps.k2) AS k2, SUM(ps.k3) AS k3, SUM(ps.k4) AS k4, SUM(ps.k5) AS k5,
+         SUM(ps.v1) AS v1, SUM(ps.v2) AS v2, SUM(ps.v3) AS v3, SUM(ps.v4) AS v4, SUM(ps.v5) AS v5,
+         SUM(ps.kast) AS kast, SUM(ps.contribution_score) AS contribution_score, SUM(ps.mvp) AS mvp
+       FROM player_stats ps
+       WHERE ps.match_id = ?
+       GROUP BY ps.steam_id, ps.team_id`,
+      [matchId]
+    );
+
+    if (!players.length) {
+      res.status(404).json({ message: "No player stats found" });
+      return;
+    }
+
+    const mvp = findMvpPlayer(players);
+    if (!mvp) {
+      res.status(404).json({ message: "No MVP found" });
+      return;
+    }
+
+    res.json(buildMvpResponse(mvp, matchRows[0], null, null));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+/** GET /mapstats/:match_id/:map_number/mvp — Best player for a specific map (map_number is 0-indexed in DB) */
+router.get("/:match_id/:map_number/mvp", async (req, res) => {
+  try {
+    const matchId = parseInt(req.params.match_id);
+    const mapNumber = parseInt(req.params.map_number);
+
+    if (isNaN(matchId) || isNaN(mapNumber)) {
+      res.status(400).json({ message: "Invalid match_id or map_number" });
+      return;
+    }
+
+    const mapStatRows: RowDataPacket[] = await db.query(
+      "SELECT id, map_name, team1_score, team2_score FROM map_stats WHERE match_id = ? AND map_number = ? LIMIT 1",
+      [matchId, mapNumber]
+    );
+
+    if (!mapStatRows.length) {
+      res.status(404).json({ message: "Map stats not found" });
+      return;
+    }
+
+    const mapStat = mapStatRows[0];
+
+    const players: RowDataPacket[] = await db.query(
+      `SELECT ps.steam_id, ps.name, ps.team_id,
+         SUM(ps.kills) AS kills, SUM(ps.deaths) AS deaths, SUM(ps.assists) AS assists,
+         SUM(ps.roundsplayed) AS roundsplayed, SUM(ps.headshot_kills) AS headshot_kills,
+         SUM(ps.damage) AS damage,
+         SUM(ps.k1) AS k1, SUM(ps.k2) AS k2, SUM(ps.k3) AS k3, SUM(ps.k4) AS k4, SUM(ps.k5) AS k5,
+         SUM(ps.v1) AS v1, SUM(ps.v2) AS v2, SUM(ps.v3) AS v3, SUM(ps.v4) AS v4, SUM(ps.v5) AS v5,
+         SUM(ps.kast) AS kast, SUM(ps.contribution_score) AS contribution_score, SUM(ps.mvp) AS mvp
+       FROM player_stats ps
+       WHERE ps.match_id = ? AND ps.map_id = ?
+       GROUP BY ps.steam_id, ps.team_id`,
+      [matchId, mapStat.id]
+    );
+
+    if (!players.length) {
+      res.status(404).json({ message: "No player stats found for this map" });
+      return;
+    }
+
+    const mvp = findMvpPlayer(players);
+    if (!mvp) {
+      res.status(404).json({ message: "No MVP found" });
+      return;
+    }
+
+    const matchRows: RowDataPacket[] = await db.query(
+      `SELECT m.team1_id, m.team2_id, m.team1_string, m.team2_string,
+              t1.name AS team1_name, t1.logo AS team1_logo,
+              t2.name AS team2_name, t2.logo AS team2_logo
+       FROM \`match\` m
+       LEFT JOIN team t1 ON t1.id = m.team1_id
+       LEFT JOIN team t2 ON t2.id = m.team2_id
+       WHERE m.id = ?`,
+      [matchId]
+    );
+
+    if (!matchRows.length) {
+      res.status(404).json({ message: "Match not found" });
+      return;
+    }
+
+    res.json(buildMvpResponse(mvp, matchRows[0], mapStat.map_name, {
+      team1_score: mapStat.team1_score,
+      team2_score: mapStat.team2_score
+    }));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: (err as Error).toString() });
+  }
+});
+
+function findMvpPlayer(players: RowDataPacket[]): (RowDataPacket & { rating: number }) | null {
+  let mvpPlayer: (RowDataPacket & { rating: number }) | null = null;
+  let maxRating = -1;
+
+  for (const player of players) {
+    const rp = parseFloat(player.roundsplayed as string) || 0;
+    if (rp > 0) {
+      const rating = Utils.getRating(
+        parseFloat(player.kills as string) || 0,
+        rp,
+        parseFloat(player.deaths as string) || 0,
+        parseFloat(player.k1 as string) || 0,
+        parseFloat(player.k2 as string) || 0,
+        parseFloat(player.k3 as string) || 0,
+        parseFloat(player.k4 as string) || 0,
+        parseFloat(player.k5 as string) || 0
+      );
+      if (rating > maxRating) {
+        maxRating = rating;
+        mvpPlayer = { ...player, rating };
+      }
+    }
+  }
+
+  return mvpPlayer;
+}
+
+function buildMvpResponse(
+  mvp: RowDataPacket & { rating: number },
+  match: RowDataPacket,
+  mapName: string | null,
+  scores: { team1_score: number; team2_score: number } | null
+) {
+  const kills = parseFloat(mvp.kills as string) || 0;
+  const deaths = parseFloat(mvp.deaths as string) || 0;
+  const assists = parseFloat(mvp.assists as string) || 0;
+  const roundsPlayed = parseFloat(mvp.roundsplayed as string) || 0;
+  const headshots = parseFloat(mvp.headshot_kills as string) || 0;
+  const damage = parseFloat(mvp.damage as string) || 0;
+
+  const isTeam1 = mvp.team_id === match.team1_id;
+  const teamName = isTeam1
+    ? (match.team1_string || match.team1_name || "Team 1")
+    : (match.team2_string || match.team2_name || "Team 2");
+  const teamLogo = isTeam1 ? match.team1_logo : match.team2_logo;
+
+  return {
+    mvp: {
+      steam_id: mvp.steam_id,
+      name: mvp.name,
+      team_id: mvp.team_id,
+      team_name: teamName,
+      team_logo: teamLogo,
+      map_name: mapName,
+      team1_score: scores?.team1_score ?? null,
+      team2_score: scores?.team2_score ?? null,
+      rating: mvp.rating,
+      kills,
+      deaths,
+      assists,
+      roundsplayed: roundsPlayed,
+      headshot_kills: headshots,
+      hsp: kills > 0 ? parseFloat(((headshots / kills) * 100).toFixed(1)) : 0,
+      adr: roundsPlayed > 0 ? parseFloat((damage / roundsPlayed).toFixed(1)) : 0,
+      kdr: deaths > 0 ? parseFloat((kills / deaths).toFixed(2)) : kills,
+      k2: parseFloat(mvp.k2 as string) || 0,
+      k3: parseFloat(mvp.k3 as string) || 0,
+      k4: parseFloat(mvp.k4 as string) || 0,
+      k5: parseFloat(mvp.k5 as string) || 0,
+      v1: parseFloat(mvp.v1 as string) || 0,
+      v2: parseFloat(mvp.v2 as string) || 0,
+      v3: parseFloat(mvp.v3 as string) || 0,
+      v4: parseFloat(mvp.v4 as string) || 0,
+      v5: parseFloat(mvp.v5 as string) || 0,
+      kast: parseFloat(mvp.kast as string) || 0,
+      mvp_count: parseFloat(mvp.mvp as string) || 0,
+      contribution_score: parseFloat(mvp.contribution_score as string) || 0
+    },
+    match: {
+      team1_id: match.team1_id,
+      team2_id: match.team2_id,
+      team1_name: match.team1_string || match.team1_name || "Team 1",
+      team2_name: match.team2_string || match.team2_name || "Team 2",
+      team1_logo: match.team1_logo,
+      team2_logo: match.team2_logo
+    }
+  };
+}
+
 export default router;

--- a/src/routes/teams.ts
+++ b/src/routes/teams.ts
@@ -19,7 +19,8 @@ import Utils from "../utility/utils.js";
 
 import { generate } from "randomstring";
 
-import { writeFile, unlink } from "fs";
+import { writeFile, unlink, mkdirSync } from "fs";
+import path from "path";
 
 import fetch from "node-fetch";
 import { RowDataPacket } from "mysql2";
@@ -416,10 +417,12 @@ router.post("/", Utils.ensureAuthenticated, async (req, res) => {
       length: 5,
       charset: "alphanumeric",
     });
+    const logosDir = path.join(process.cwd(), "public", "img", "logos");
+    mkdirSync(logosDir, { recursive: true });
     if (logo.includes("data:image/png;base64")) {
       let base64Data: string = logo.replace(/^data:image\/png;base64,/, "");
       writeFile(
-        "public/img/logos/" + logoName + ".png",
+        path.join(logosDir, logoName + ".png"),
         base64Data,
         "base64",
         err => {
@@ -430,15 +433,15 @@ router.post("/", Utils.ensureAuthenticated, async (req, res) => {
       let base64Data: string = Buffer.from(logo).toString('base64').replace(/^data:image\/([\w+]+);base64,([\s\S]+)/, "");
       let baseImg: any = img(Buffer.from(base64Data, 'base64').toString());
       writeFile(
-        "public/img/logos/" + logoName + ".svg",
+        path.join(logosDir, logoName + ".svg"),
         baseImg.base64,
-        { encoding: 'base64' }, 
+        { encoding: 'base64' },
         err => {
           if (err) console.error(err);
         }
       );
     }
-    
+
   }
   let newTeam: Array<TeamData> = [
     {
@@ -585,10 +588,12 @@ router.put("/", Utils.ensureAuthenticated, async (req, res) => {
       res.status(413).json({ message: "Logo image too large (max 2MB)." });
       return;
     }
+    const logosDir = path.join(process.cwd(), "public", "img", "logos");
+    mkdirSync(logosDir, { recursive: true });
     if (teamLogo.includes("data:image/png;base64")) {
       let base64Data: string = teamLogo.replace(/^data:image\/png;base64,/, "");
       writeFile(
-        "public/img/logos/" + logoName + ".png",
+        path.join(logosDir, logoName + ".png"),
         base64Data,
         "base64",
         err => {
@@ -599,9 +604,9 @@ router.put("/", Utils.ensureAuthenticated, async (req, res) => {
       let base64Data: string = Buffer.from(teamLogo).toString('base64').replace(/^data:image\/([\w+]+);base64,([\s\S]+)/, "");
       let baseImg: any = img(Buffer.from(base64Data, 'base64').toString());
       writeFile(
-        "public/img/logos/" + logoName + ".svg",
+        path.join(logosDir, logoName + ".svg"),
         baseImg.base64,
-        { encoding: 'base64' }, 
+        { encoding: 'base64' },
         err => {
           if (err) console.error(err);
         }


### PR DESCRIPTION
## Summary

This PR adds comprehensive MVP (Most Valuable Player) functionality to the API, including:
- New REST endpoints to retrieve MVP data for full matches and individual maps
- A complete MVP image generator with customizable styling and layout
- Support for team logos, player images, and map backgrounds in MVP cards
- Player image upload endpoint for personalized MVP displays

## Key Changes

### New Endpoints (`src/routes/mapstats.ts`)
- **GET `/mapstats/:match_id/mvp`** — Returns aggregated MVP stats across all maps of a match, determined by highest HLTV 2.0 rating
- **GET `/mapstats/:match_id/:map_number/mvp`** — Returns MVP stats for a specific map
- Both endpoints return comprehensive player stats (kills, deaths, assists, rating, headshot %, ADR, K/D, multi-kills, clutches, KAST, MVP count)

### MVP Image Generator (`src/routes/image/generators/mvp.ts`)
- New `generateMapMvpImage()` function that renders customizable MVP cards with:
  - Team logos (with fallback to country flags)
  - Player profile image (supports circular crop)
  - Map background image (with dark overlay for readability)
  - Team names, scores, and player stats
  - Configurable shapes (team pills, player pill, stats bar) with transparency and borders
  - Column headers for stats labels
  - Full font customization via settings

### Image Routes (`src/routes/image/image.ts`)
- **GET `/image/match/:match_id/mvp`** — Generates MVP image for full match (series score)
- **GET `/image/match/:match_id/map/:map_number/mvp`** — Generates MVP image for specific map
- **GET `/image/players`** — Lists available player images in `public/img/players/`
- **POST `/image/upload/player`** — Upload player image by Steam ID (17-digit format)

### Settings & Configuration (`src/routes/image/settings.ts`, `src/routes/image/types.ts`)
- Added `LogoConfig` interface for team logo positioning and sizing
- Extended `ImageSettings` with complete `mvp` configuration section including:
  - Text fields (map name, team names, scores, player name, stats)
  - Logo positioning for both teams
  - Player image settings (size, position, circular crop option)
  - Graphical shapes (team pill, player pill, stats bar) with fill, alpha, borders
  - Column headers for stat labels
  - Map image and player image toggles
- Added `team1_logo` and `team2_logo` to match image settings

### Image Asset Loading (`src/routes/image/generators/match.ts`, `src/routes/image/generators/mvp.ts`)
- Extracted and reused logo/flag loading utilities:
  - `tryLoadLogo()` — Loads from `public/img/logos/` with multiple extensions
  - `tryLoadFlag()` — Loads from `public/img/flags/` or falls back to flagcdn.com CDN
  - `tryLoadLogoOrFlag()` — Tries logo first, then flag as fallback
  - `tryLoadMapImage()` — Loads map images with prefix stripping (de_, cs_, ar_)
  - `tryLoadPlayerImage()` — Loads player-specific or default image
- Applied logo loading to match image generator as well

### Database & Types
- Extended `MatchRow` type to include `team1_logo`, `team2_logo`, `team1_flag`, `team2_flag`
- Added `PlayerStatExtended` type for aggregated player stats with rating calculation
- Updated match queries to fetch team logos and flags

### File System Improvements (`src/routes/teams.ts`, `app.ts`)
- Improved path handling for logo directory creation using `path.join()`
- Added static routes for player images and flags in Express

## Implementation Details

- MVP selection uses HLTV 2.0 rating formula (via `Utils.getRating()`) across aggregated stats
- For full-match MVP, map images are disabled to show the background instead
- Player images support both rectangular and circular crops

https://claude.ai/code/session_01Y9kq5XTicQXGJrJ1Ndg4hY