### PR TITLE
Replace 'de_vertigo' with 'de_cache' in queue and update auth.ts

### DIFF
--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -90,7 +90,7 @@ export class QueueService {
       "de_nuke",
       "de_anubis",
       "de_dust2",
-      "de_vertigo",
+      "de_cache",
     ];
 
     // Fetch season params and cvars

--- a/src/utility/auth.ts
+++ b/src/utility/auth.ts
@@ -87,7 +87,7 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
         defaultMaps.push(['de_nuke', 'Nuke', curUser[0].id]);
         defaultMaps.push(['de_anubis', 'Anubis', curUser[0].id]);
         defaultMaps.push(['de_dust2', 'Dust II', curUser[0].id]);
-        defaultMaps.push(['de_vertigo', 'Vertigo', curUser[0].id]);
+        defaultMaps.push(['de_cache', 'Cache', curUser[0].id]);
         sql = "INSERT INTO map_list (map_name, map_display_name, user_id) VALUES ?";
         await db.query(sql, [defaultMaps]);
       } else {


### PR DESCRIPTION
This pull request updates the default map pool by replacing "de_vertigo" with "de_cache" in both the queue service and user authentication logic. This ensures consistency in the available maps for users and the system.

**Map Pool Update:**

* Replaced `"de_vertigo"` with `"de_cache"` in the default map list returned by `QueueService` in `src/services/queue.ts`.
* Updated the default maps inserted for new users in the authentication utility to use `"de_cache"` instead of `"de_vertigo"` in `src/utility/auth.ts`.